### PR TITLE
feat(adapter): instrument epsagon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,17 @@
 {
   "name": "@adobe/helix-deploy",
-  "version": "1.4.0-test",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@adobe/helix-epsagon": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-epsagon/-/helix-epsagon-1.5.5.tgz",
+      "integrity": "sha512-kMBw652c/sbHzJAzXhBfw+IVIn9MM8PuAqYg78IdJSzKJqfr7133v47EGM1YV+bYvyIut9jmzkTKmwycmiAwbQ==",
+      "requires": {
+        "epsagon": "1.102.2"
+      }
+    },
     "@adobe/helix-fetch": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@adobe/helix-fetch/-/helix-fetch-1.7.0.tgz",
@@ -2727,6 +2735,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3000,8 +3016,7 @@
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-      "dev": true
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "check-error": {
       "version": "1.0.2",
@@ -3424,8 +3439,7 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-      "dev": true
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -3758,6 +3772,21 @@
       "requires": {
         "execa": "^4.0.0",
         "java-properties": "^1.0.0"
+      }
+    },
+    "epsagon": {
+      "version": "1.102.2",
+      "resolved": "https://registry.npmjs.org/epsagon/-/epsagon-1.102.2.tgz",
+      "integrity": "sha512-smuT41bQ1nye7EblygpENeB5pISYHWcrM2WMlIvPLETDuI7vQT+bnBcNLn6uGtZfNpyk/yGRlVXRxLteerUjPg==",
+      "requires": {
+        "axios": "^0.19.0",
+        "google-protobuf": "^3.5.0",
+        "json.sortify": "^2.2.2",
+        "md5": "^2.2.1",
+        "require-in-the-middle": "^5.0.3",
+        "shimmer": "^1.2.1",
+        "uuid-parse": "^1.1.0",
+        "uuid4": "^1.0.0"
       }
     },
     "error-ex": {
@@ -4620,6 +4649,29 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -4864,6 +4916,11 @@
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
       }
+    },
+    "google-protobuf": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.14.0.tgz",
+      "integrity": "sha512-bwa8dBuMpOxg7COyqkW6muQuvNnWgVN8TX/epDRGW5m0jcrmq2QJyCyiV8ZE2/6LaIIqJtiv9bYokFhfpy/o6w=="
     },
     "graceful-fs": {
       "version": "4.2.3",
@@ -5178,8 +5235,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -5583,6 +5639,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json.sortify": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json.sortify/-/json.sortify-2.2.2.tgz",
+      "integrity": "sha512-wwFLdDffs747s5cqLA3htIKp9wdID2rWNofJKxwDjFo+rqqt5Vg7SnYOh7mc7MW6Iw43rrOFhr6MKytOtNceSA=="
     },
     "json5": {
       "version": "1.0.1",
@@ -5991,7 +6052,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "dev": true,
       "requires": {
         "charenc": "~0.0.1",
         "crypt": "~0.0.1",
@@ -6740,6 +6800,11 @@
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
+    },
+    "module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
     },
     "ms": {
       "version": "2.1.2",
@@ -10896,8 +10961,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -11368,6 +11432,26 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "require-in-the-middle": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.0.3.tgz",
+      "integrity": "sha512-p/ICV8uMlqC4tjOYabLMxAWCIKa0YUQgZZ6KDM0xgXJNgdGQ1WmL2A07TwmrZw+wi6ITUFKzH5v3n+ENEyXVkA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
+      }
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -11378,7 +11462,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
       "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -11838,6 +11921,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -12872,6 +12960,16 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
+    "uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A=="
+    },
+    "uuid4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-1.1.4.tgz",
+      "integrity": "sha512-Gr1q2k40LpF8CokcnQFjPDsdslzJbTCTBG5xQIEflUov431gFkY5KduiGIeKYAamkQnNn4IfdHJbLnl9Bib8TQ=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
+    "@adobe/helix-epsagon": "1.5.5",
     "@adobe/helix-fetch": "^1.7.0",
     "@aws-sdk/client-apigatewayv2": "^1.0.0-rc.8",
     "@aws-sdk/client-lambda": "^1.0.0-rc.8",

--- a/src/template/index.js
+++ b/src/template/index.js
@@ -12,6 +12,8 @@
 /* eslint-disable no-param-reassign, no-underscore-dangle, import/no-extraneous-dependencies */
 const { Request } = require('node-fetch');
 const { promisify } = require('util');
+const { epsagon } = require('@adobe/helix-epsagon');
+
 // eslint-disable-next-line  import/no-unresolved
 const { main } = require('./main.js');
 /*
@@ -70,7 +72,7 @@ async function getAWSSecrets(functionName) {
 }
 
 // Azure
-module.exports = async function azure(context, req) {
+async function azure(context, req) {
   context.log('JavaScript HTTP trigger function processed a request.');
   // eslint-disable-next-line global-require, import/no-unresolved
   const params = require('./params.json');
@@ -137,10 +139,10 @@ module.exports = async function azure(context, req) {
       body: e.message,
     };
   }
-};
+}
 
 // OW
-module.exports.main = async function openwhisk(params = {}) {
+async function openwhisk(params = {}) {
   try {
     let body;
     if (!/^(GET|HEAD)$/i.test(params.__ow_method)) {
@@ -203,10 +205,10 @@ module.exports.main = async function openwhisk(params = {}) {
       body: `${e.message}\n${e.stack}`,
     };
   }
-};
+}
 
 // Google
-module.exports.google = async (req, res) => {
+async function google(req, res) {
   try {
     const request = new Request(`https://${req.hostname}/${process.env.K_SERVICE}${req.originalUrl}`, {
       method: req.method,
@@ -244,10 +246,10 @@ module.exports.google = async (req, res) => {
   } catch (e) {
     res.status(500).send(e.message);
   }
-};
+}
 
 // AWS
-module.exports.lambda = async function lambda(event, context) {
+async function lambda(event, context) {
   try {
     const request = new Request(`https://${event.requestContext.domainName}${event.rawPath}${event.rawQueryString ? '?' : ''}${event.rawQueryString}`, {
       method: event.requestContext.http.method,
@@ -297,4 +299,11 @@ module.exports.lambda = async function lambda(event, context) {
       body: e.message,
     };
   }
-};
+}
+
+// exports
+module.exports = Object.assign(azure, {
+  main: epsagon(openwhisk),
+  lambda,
+  google,
+});


### PR DESCRIPTION
currently, it's easiest to instrument epsagon in the adapter, since it already wraps the openwhisk action.
but, since we deploy the action `raw`, it no longer has (request) params to report:

![image](https://user-images.githubusercontent.com/917628/102440581-d7b78280-4063-11eb-9345-6f173f7fa4ba.png)

we could try to create a new universal-adapter for epsagon or just ensure that the `__ow_query` params are also added as params (by fixing node-espagon diretctly)