### PR TITLE
fix(wsk): invoke via API doesn't propagate params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-deploy",
-  "version": "1.13.0",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4638,6 +4638,16 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5535,6 +5545,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-path-cwd": {
@@ -6850,6 +6866,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -11172,6 +11194,17 @@
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
+      }
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "mocha-junit-reporter": "2.0.0",
     "nock": "13.0.5",
     "nyc": "15.1.0",
+    "proxyquire": "2.1.3",
     "semantic-release": "17.3.0",
     "yauzl": "2.10.0"
   },

--- a/test/aws.integration.js
+++ b/test/aws.integration.js
@@ -63,7 +63,7 @@ describe('AWS Integration Test', () => {
     const res = await builder.run();
     assert.ok(res);
     const out = builder.cfg._logger.output;
-    assert.ok(out.indexOf('ok: 200\nHello, world.') > 0, out);
+    assert.ok(out.indexOf('{"url":"https://lqmig3v5eb.execute-api.us-east-1.amazonaws.com/simple-package/simple-name/1.45.0/foo","file":"Hello, world.\\n"}') > 0, out);
   }).timeout(50000);
 
   it('Update links to AWS (for real)', async () => {
@@ -90,6 +90,6 @@ describe('AWS Integration Test', () => {
     assert.ok(ret.ok);
     assert.equal(ret.status, 200);
     const text = await ret.text();
-    assert.equal(text.trim(), 'Hello, world.');
+    assert.equal(text.trim(), '{"url":"https://lqmig3v5eb.execute-api.us-east-1.amazonaws.com/simple-package/simple-name/v1/foo","file":"Hello, world.\\n"}');
   }).timeout(50000);
 });

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -135,7 +135,7 @@ describe('Build Test', () => {
     // eslint-disable-next-line global-require,import/no-dynamic-require
     const { main } = require(path.resolve(zipDir, 'index.js'));
     const ret = await main({});
-    assert.deepEqual(await ret.body, 'Hello, world.\n');
+    assert.deepEqual(await ret.body, '{"url":"https://localhost/api/v1/webundefined","file":"Hello, world.\\n"}');
   })
     .timeout(5000);
 });

--- a/test/fixtures/simple/index.js
+++ b/test/fixtures/simple/index.js
@@ -14,5 +14,9 @@ const reader = require('./helper/read.js');
 
 // eslint-disable-next-line no-unused-vars
 module.exports.main = function main(req, context) {
-  return new Response(reader());
+  const resp = JSON.stringify({
+    url: req.url,
+    file: reader(),
+  });
+  return new Response(resp);
 };

--- a/test/gateway.integration.js
+++ b/test/gateway.integration.js
@@ -59,7 +59,8 @@ describe('Gateway Integration Test', () => {
     const res = await builder.run();
     assert.ok(res);
     const out = builder.cfg._logger.output;
+    const { namespace } = builder._deployers.wsk._cfg;
     assert.ok(out.indexOf(`ok: 200
-Hello, world.`) > 0, out);
+{"url":"https://adobeioruntime.net/api/v1/web/${namespace}/simple-package/simple-name@1.45.0/foo","file":"Hello, world.\\n"}`) > 0, out);
   }).timeout(150000);
 });

--- a/test/openwhisk.adapter.test.js
+++ b/test/openwhisk.adapter.test.js
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-underscore-dangle */
+const assert = require('assert');
+const { Response } = require('node-fetch');
+const proxyquire = require('proxyquire');
+
+describe('OpenWhisk Adapter Test', () => {
+  beforeEach(() => {
+    process.env.__OW_ACTION_NAME = '/simple-package/simple-name';
+    process.env.__OW_ACTIVATION_ID = '1234';
+    process.env.__OW_API_HOST = 'https://test.com';
+  });
+
+  it('Adapts with empty params', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: () => new Response(),
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({});
+    assert.deepEqual(resp, {
+      body: '',
+      headers: {},
+      statusCode: 200,
+    });
+  });
+
+  it('Propagates query', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: (req) => {
+          const ret = JSON.stringify({
+            url: req.url,
+          });
+          return new Response(ret);
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({
+      __ow_query: 'foo=bar&zoo=42',
+    });
+    resp.body = JSON.parse(resp.body);
+    assert.deepEqual(resp, {
+      body: {
+        url: 'https://test.com/api/v1/web/simple-package/simple-name?foo=bar&zoo=42',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      statusCode: 200,
+    });
+  });
+
+  it('Propagates query and params and populates env', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: (req, context) => {
+          const ret = JSON.stringify({
+            url: req.url,
+            secret: context.env.SECRET_TOKEN,
+          });
+          return new Response(ret);
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({
+      test: 'dummy',
+      __ow_query: 'foo=bar&zoo=42',
+      SECRET_TOKEN: 'xyz',
+    });
+    resp.body = JSON.parse(resp.body);
+    assert.deepEqual(resp, {
+      body: {
+        url: 'https://test.com/api/v1/web/simple-package/simple-name?foo=bar&zoo=42&test=dummy',
+        secret: 'xyz',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      statusCode: 200,
+    });
+  });
+
+  it('Respects path, headers and method', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: (req, context) => {
+          const ret = JSON.stringify({
+            url: req.url,
+            secret: context.env.SECRET_TOKEN,
+            method: req.method,
+            headers: req.headers.raw(),
+          });
+          return new Response(ret);
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({
+      test: 'dummy',
+      __ow_query: 'foo=bar&zoo=42',
+      __ow_path: '/test-suffix',
+      __ow_headers: {
+        'x-test-header': 42,
+      },
+      __ow_method: 'PUT',
+      SECRET_TOKEN: 'xyz',
+    });
+    resp.body = JSON.parse(resp.body);
+    assert.deepEqual(resp, {
+      body: {
+        headers: {
+          'x-test-header': [
+            '42',
+          ],
+        },
+        method: 'PUT',
+        secret: 'xyz',
+        url: 'https://test.com/api/v1/web/simple-package/simple-name/test-suffix?foo=bar&zoo=42&test=dummy',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+        'x-last-activation-id': '1234',
+      },
+      statusCode: 200,
+    });
+  });
+
+  it('populates body', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: async (req) => {
+          const ret = JSON.stringify({
+            body: await req.text(),
+          });
+          return new Response(ret);
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({
+      test: 'dummy',
+      __ow_body: 'hello, world.',
+      __ow_method: 'PUT',
+      __ow_headers: {
+        'content-type': 'text/plain',
+      },
+    });
+    resp.body = JSON.parse(resp.body);
+    assert.deepEqual(resp, {
+      body: {
+        body: 'hello, world.',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+        'x-last-activation-id': '1234',
+      },
+      statusCode: 200,
+    });
+  });
+
+  it('populates binary body', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: async (req) => {
+          const ret = JSON.stringify({
+            body: await req.text(),
+          });
+          return new Response(ret);
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({
+      test: 'dummy',
+      __ow_body: Buffer.from('hello, world.').toString('base64'),
+      __ow_method: 'PUT',
+      __ow_headers: {
+        'content-type': 'application/octet-stream',
+      },
+    });
+    resp.body = JSON.parse(resp.body);
+    assert.deepEqual(resp, {
+      body: {
+        body: 'hello, world.',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+        'x-last-activation-id': '1234',
+      },
+      statusCode: 200,
+    });
+  });
+
+  it('uses localhost if no env var', async () => {
+    delete process.env.__OW_API_HOST;
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: (req) => {
+          const ret = JSON.stringify({
+            url: req.url,
+          });
+          return new Response(ret);
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({});
+    resp.body = JSON.parse(resp.body);
+    assert.deepEqual(resp, {
+      body: {
+        url: 'https://localhost/api/v1/web/simple-package/simple-name',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      statusCode: 200,
+    });
+  });
+
+  it('respects x-forwarded-host', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: (req) => {
+          const ret = JSON.stringify({
+            url: req.url,
+          });
+          return new Response(ret);
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({
+      __ow_headers: {
+        'x-forwarded-host': 'adobeioruntime.net,test.com',
+      },
+    });
+    resp.body = JSON.parse(resp.body);
+    assert.deepEqual(resp, {
+      body: {
+        url: 'https://adobeioruntime.net/api/v1/web/simple-package/simple-name',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      statusCode: 200,
+    });
+  });
+
+  it('responds with 500 on error', async () => {
+    const { main } = proxyquire('../src/template/index.js', {
+      './main.js': {
+        main: () => {
+          throw Error('boing!');
+        },
+        '@noCallThru': true,
+      },
+    });
+
+    const resp = await main({
+      __ow_headers: {
+        'x-forwarded-host': 'adobeioruntime.net,test.com',
+      },
+    });
+    assert.deepEqual(resp, {
+      body: 'Internal Server Error',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      statusCode: 500,
+    });
+  });
+});

--- a/test/openwhisk.integration.js
+++ b/test/openwhisk.integration.js
@@ -15,8 +15,18 @@
 const assert = require('assert');
 const fse = require('fs-extra');
 const path = require('path');
+const fetchAPI = require('@adobe/helix-fetch');
 const { createTestRoot, TestLogger } = require('./utils');
 const CLI = require('../src/cli.js');
+
+function fetchContext() {
+  return process.env.HELIX_FETCH_FORCE_HTTP1
+    ? fetchAPI.context({
+      httpProtocol: 'http1',
+      httpsProtocols: ['http1'],
+    })
+    : fetchAPI;
+}
 
 describe('OpenWhisk Integration Test', () => {
   let testRoot;
@@ -52,6 +62,35 @@ describe('OpenWhisk Integration Test', () => {
     assert.ok(res);
     const out = builder.cfg._logger.output;
     assert.ok(out.indexOf(`ok: 200
-Hello, world.`) > 0, out);
-  }).timeout(10000);
+{"url":"https://adobeioruntime.net/api/v1/web/tripod/simple-package/simple-name@1.45.0/foo","file":"Hello, world.\\n"}`) > 0, out);
+
+    // try to invoke via openwhisk api
+    const { fetch } = fetchContext();
+    const auth = Buffer.from(builder._deployers.wsk._cfg.auth).toString('base64');
+    const resp = await fetch('https://adobeioruntime.net/api/v1/namespaces/_/actions/simple-package/simple-name@1.45.0?blocking=true&result=true', {
+      method: 'POST',
+      body: JSON.stringify({
+        foo: 'bar',
+        __ow_headers: {
+          'x-forwarded-host': 'adobeioruntime.net',
+        },
+      }),
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Basic ${auth}`,
+      },
+    });
+    const ret = await resp.json();
+    ret.body = JSON.parse(ret.body);
+    assert.deepEqual(ret, {
+      body: {
+        file: 'Hello, world.\n',
+        url: 'https://adobeioruntime.net/api/v1/web/tripod/simple-package/simple-name@1.45.0?foo=bar',
+      },
+      headers: {
+        'content-type': 'text/plain;charset=UTF-8',
+      },
+      statusCode: 200,
+    });
+  }).timeout(20000);
 });


### PR DESCRIPTION
fixes #48

rewrote parameter passing:
- all the params from `__ow_query` are appended to the `Request.url`
- all the params from `params` that don't match the _SECRET_ filter are appended to the `Request.url`
- added specific openwhisk adapter test