### PR TITLE
fix(gateway): extract package name from URL instead of config

### DIFF
--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -84,9 +84,9 @@ class AWSDeployer extends BaseDeployer {
     return `${this._cfg.apiId}.execute-api.${this._cfg.region}.amazonaws.com`;
   }
 
+  // eslint-disable-next-line class-methods-use-this
   get urlVCL() {
-    const { cfg } = this;
-    return `"/${cfg.packageName}" + regsub(req.url, "@", "/")`;
+    return '"/" + var.package + "/" + var.action + var.slashversion + var.rest';
   }
 
   get functionPath() {

--- a/src/deploy/OpenWhiskDeployer.js
+++ b/src/deploy/OpenWhiskDeployer.js
@@ -61,7 +61,7 @@ class OpenWhiskDeployer extends BaseDeployer {
 
   // eslint-disable-next-line class-methods-use-this
   get urlVCL() {
-    return `"/api/v1/web/${this._cfg.namespace}/${this.cfg.packageName}" + req.url`;
+    return `"/api/v1/web/${this._cfg.namespace}/" + var.package + "/" + var.action + var.atversion + var.rest`;
   }
 
   get fullFunctionName() {

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -66,10 +66,30 @@ class FastlyGateway {
 
   setURLVCL() {
     const pre = `
-declare local var.namespace STRING;
 declare local var.package STRING;
 declare local var.action STRING;
 declare local var.version STRING;
+declare local var._version STRING;
+declare local var.atversion STRING;
+declare local var.slashversion STRING;
+declare local var.rest STRING;
+
+set var.version = "";
+set var.rest = "";
+
+if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
+  log "match";
+  set var.package = re.group.1;
+  set var.action = re.group.2;
+  set var.version = re.group.3;
+
+  set var.rest = re.group.5;
+
+  // normalize version divider
+  set var._version = regsub(var.version, "[@_]", "_");
+  set var.atversion = regsub(var.version, "[@_]", "@");
+  set var.slashversion = regsub(var.version, "[@_]", "/");
+}
 `;
     return pre + this._deployers.map((deployer) => `
       if (req.backend == F_${deployer.name}) {

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -176,7 +176,7 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
         name: 'passurl',
         priority: 10,
         dynamic: 0,
-        type: 'miss',
+        type: 'pass',
         content: this.setURLVCL(),
       });
 

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -65,7 +65,13 @@ class FastlyGateway {
   }
 
   setURLVCL() {
-    return this._deployers.map((deployer) => `
+    const pre = `
+declare local var.namespace STRING;
+declare local var.package STRING;
+declare local var.action STRING;
+declare local var.version STRING;
+`;
+    return pre + this._deployers.map((deployer) => `
       if (req.backend == F_${deployer.name}) {
         set bereq.url = ${deployer.urlVCL};
       }

--- a/test/gateway.integration.js
+++ b/test/gateway.integration.js
@@ -74,13 +74,13 @@ describe('Gateway Integration Test', () => {
 {"url":"https://azure.adobe-runtime.com/api/v1/web/${namespace}/simple-package/simple-name@1.45.0/foo","file":"Hello, world.\\n"}`) > 0, out);
 
     const { fetch } = fetchContext();
-    const respRandom = await fetch('https://deploy-test.anywhere.run/simple-name@1.45.0/foo');
-    const respOW = await fetch('https://deploy-test.anywhere.run/simple-name@1.45.0/foo', {
+    const respRandom = await fetch('https://deploy-test.anywhere.run/simple-package/simple-name@1.45.0/foo');
+    const respOW = await fetch('https://deploy-test.anywhere.run/simple-package/simple-name@1.45.0/foo', {
       headers: {
         'x-ow-version-lock': 'env=openwhisk',
       },
     });
-    const respAWS = await fetch('https://deploy-test.anywhere.run/simple-name@1.45.0/foo', {
+    const respAWS = await fetch('https://deploy-test.anywhere.run/simple-package/simple-name@1.45.0/foo', {
       headers: {
         'x-ow-version-lock': 'env=amazonwebservices',
       },


### PR DESCRIPTION
This changes all Gateway URLs as the package name is now the required first path segment.

BREAKING CHANGE: fixes #80 and breaks all Gateway URLs