### PR TITLE
Dynamic Backend Priorities

### DIFF
--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -48,7 +48,7 @@ class FastlyGateway {
     const init = this._deployers.map((deployer) => `declare local var.${deployer.name.toLowerCase()} INTEGER;`);
 
     // get the desired weight for each backend
-    const set = this._deployers.map((deployer) => `set var.${deployer.name.toLowerCase()} = std.atoi(table.lookup(priorities, "${deployer.name.toLowerCase()}", ${Math.floor((100 / this._deployers.length))}));`);
+    const set = this._deployers.map((deployer) => `set var.${deployer.name.toLowerCase()} = std.atoi(table.lookup(priorities, "${deployer.name.toLowerCase()}", "${Math.floor((100 / this._deployers.length))}"));`);
 
     // for all but the first, sum up the weights
     const increment = this._deployers

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -109,6 +109,11 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
         type: 'request',
       });
 
+      await this._fastly.writeDictionary(newversion, 'priorities', {
+        name: 'priorities',
+        write_only: 'false',
+      });
+
       // set up health checks
       await Promise.all(this._deployers
         .map((deployer) => ({

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -46,7 +46,7 @@ class FastlyGateway {
   getLimit(i) {
     const sum = this._deployers.slice(0, i + 1)
       .map((deployer) => deployer.name)
-      .map((name) => `table.lookup_integer(priorities, '${name}', ${Math.floor((100 / this._deployers.length) * (i + 1))})`)
+      .map((name) => `table.lookup_integer(priorities, '${name}', ${Math.floor((100 / this._deployers.length))})`)
       .join(' + ');
     return `(${sum})`;
   }

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -44,10 +44,13 @@ class FastlyGateway {
   }
 
   selectBackendVCL() {
+    // declare a local variable for each backend
     const init = this._deployers.map((deployer) => `declare local var.${deployer.name.toLowerCase()} INTEGER;`);
 
-    const set = this._deployers.map((deployer) => `set var.${deployer.name.toLowerCase()} = table.lookup_integer(priorities, "${deployer.name.toLowerCase()}", ${Math.floor((100 / this._deployers.length))})`);
+    // get the desired weight for each backend
+    const set = this._deployers.map((deployer) => `set var.${deployer.name.toLowerCase()} = std.atoi(table.lookup(priorities, "${deployer.name.toLowerCase()}", ${Math.floor((100 / this._deployers.length))}));`);
 
+    // for all but the first, sum up the weights
     const increment = this._deployers
       .slice(1)
       .map((deployer, i) => ([deployer.name, this._deployers[i].name]))

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -60,7 +60,7 @@ class FastlyGateway {
       declare local var.i INTEGER;
       set var.i = randomint(0, 100);
 
-      set req.http.X-Backend-Health = ${this._deployers.map((deployer) => `backend.F_${deployer.name.toLowerCase()}.healthy`).join(' + " " + ')};
+      set req.http.X-Backend-Health = ${this._deployers.map((deployer) => `backend.F_${deployer.name}.healthy`).join(' + " " + ')};
 
       if (false) {}`;
 

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -45,8 +45,8 @@ class FastlyGateway {
 
   getLimit(i) {
     const sum = this._deployers.slice(0, i + 1)
-      .map(deployer => deployer.name)
-      .map(name => `table.lookup_integer(priorities, '${name}', ${Math.floor(100 / this._deployers.length * (i + 1))})`)
+      .map((deployer) => deployer.name)
+      .map((name) => `table.lookup_integer(priorities, '${name}', ${Math.floor((100 / this._deployers.length) * (i + 1))})`)
       .join(' + ');
     return `(${sum})`;
   }
@@ -60,7 +60,7 @@ class FastlyGateway {
 
       if (false) {}`;
 
-    const middle = this._deployers.map((deployer, i) => `if((var.i <= ${getLimit(i)} && backend.F_${deployer.name}.healthy) && subfield(req.http.x-ow-version-lock, "env", "&") !~ ".?" || subfield(req.http.x-ow-version-lock, "env", "&") == "${deployer.name.toLowerCase()}") {
+    const middle = this._deployers.map((deployer, i) => `if((var.i <= ${this.getLimit(i)} && backend.F_${deployer.name}.healthy) && subfield(req.http.x-ow-version-lock, "env", "&") !~ ".?" || subfield(req.http.x-ow-version-lock, "env", "&") == "${deployer.name.toLowerCase()}") {
       set req.backend = F_${deployer.name};
     }`);
 


### PR DESCRIPTION
Each service will now have an edge dictionary for backend priorities, so that we can shift traffic from one backend to another like this:


<img width="1274" alt="Screen Shot 2021-02-17 at 12 17 58" src="https://user-images.githubusercontent.com/39613/108197080-2e9c0f80-711a-11eb-8015-f495934ea262.png">

We can then establish an escalation protocol to shift traffic back and forth.


Fixes #112 

Rationale explained in https://github.com/adobe/helix-status/pull/284#issuecomment-780510463

> - adobe/helix-pages#695 would use the built-in health check of the html action, but only for spot checking and only as a last resort
> - adobe/helix-deploy#113 allows an operator to shift the entire traffic distribution to a different runtime after being alerted by New Relic and back once the issue has been resolved.