### PR TITLE
fix(logging): cleanup action name in logs

### DIFF
--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -129,7 +129,7 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
           json: {
             ow: {
               environment: str(vcl`regsub(req.backend, ".*_", "")`),
-              actionName: str(vcl`regsub(req.url, "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)", "\\\\1/\\\\2\\\\3")`),
+              actionName: str(vcl`regsub(req.url, "^/([^/]+)/([^/@_]+)([@_]([^/@_?]+)+)?(.*$)", "\\\\1/\\\\2@\\\\4")`),
             },
             time: {
               start: str(


### PR DESCRIPTION
our current logs include values like `helix-services/dispatch@v4?static.owner=adobe&static.repo=helix-pages&static.ref=everything-universal&static.root=` in the logs for `actionName`. This change cleans this up to `helix-services/dispatch@v4`
