### PR TITLE
tune logging

### DIFF
--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -110,6 +110,16 @@ class AWSDeployer extends BaseDeployer {
     return `${this.functionPath}`;
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  get customVCL() {
+    // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html
+    // set X-Amzn-Trace-Id (tracing from x-cdn-request-id)
+    return `if (req.http.x-cdn-request-id != "") {
+      # aws trace id: root/self + version + timestamp + id (stripped of dashes)
+      set req.http.X-Amzn-Trace-Id = "Root=1" + now.sec + req.http.x-cdn-request-id;
+    }`;
+  }
+
   validate() {
     if (!this._cfg.role || !this._cfg.region) {
       throw Error('AWS target needs --aws-region and --aws-role');

--- a/src/deploy/OpenWhiskDeployer.js
+++ b/src/deploy/OpenWhiskDeployer.js
@@ -68,6 +68,14 @@ class OpenWhiskDeployer extends BaseDeployer {
     return `/${this._cfg.namespace}/${this.cfg.packageName}/${this.cfg.name}`;
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  get customVCL() {
+    // set x-request-id (tracing from x-cdn-request-id)
+    return `if (req.http.x-cdn-request-id != "") {
+      set req.http.x-request-id = req.http.x-cdn-request-id;
+    }`;
+  }
+
   ready() {
     return !!this._cfg.apiHost && !!this._cfg.auth && !!this._cfg.namespace;
   }

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -185,6 +185,7 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
               header_size: vcl`req.header_bytes_read`,
               body_size: vcl`req.body_bytes_read`,
               restarts: vcl`req.restarts`,
+              versionlock: req`X-OW-Version-Lock`,
             },
             origin: {
               host: str('%v'),

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -192,7 +192,7 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
               url: str(vcl`if(req.http.x-backend-url, req.http.x-backend-url, req.url)`),
             },
             response: {
-              status: str('%s'),
+              status: '%s',
               content_type: res`Content-Type`,
               header_size: vcl`resp.header_bytes_written`,
               body_size: '%B',

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -69,6 +69,7 @@ class FastlyGateway {
 
     const middle = this._deployers.map((deployer) => `if((var.i <= var.${deployer.name.toLowerCase()} && backend.F_${deployer.name}.healthy) && subfield(req.http.x-ow-version-lock, "env", "&") !~ ".?" || subfield(req.http.x-ow-version-lock, "env", "&") == "${deployer.name.toLowerCase()}") {
       set req.backend = F_${deployer.name};
+      ${this._deployers[0].customVCL}
     }`);
 
     const fallback = `{
@@ -130,6 +131,13 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
             ow: {
               environment: str(vcl`regsub(req.backend, ".*_", "")`),
               actionName: str(vcl`regsub(req.url, "^/([^/]+)/([^/@_]+)([@_]([^/@_?]+)+)?(.*$)", "\\\\1/\\\\2@\\\\4")`),
+              activationId: concat(
+                vcl`if(resp.http.x-openwhisk-activation-id != "", resp.http.x-openwhisk-activation-id, "")`,
+              ),
+              transactionId: concat(
+                vcl`if(resp.http.x-request-id != "", resp.http.x-request-id, "")`,
+                vcl`if(req.http.x-amazn-trace-id != "", req.http.x-amazn-trace-id, "")`,
+              ),
             },
             time: {
               start: str(


### PR DESCRIPTION
- feat(gateway): log the version lock header value
- fix(gateway): log status code as integer instead of string
- feat(gateway): trace aws and openwhisk transaction ids

We are now passing `x-cdn-request-id` into OW as `x-request-id` and into AWS as `x-amazn-trace-id`.