### PR TITLE
Gateway aliases

### DIFF
--- a/src/ActionBuilder.js
+++ b/src/ActionBuilder.js
@@ -603,6 +603,13 @@ module.exports = class ActionBuilder {
       await this._gateways.fastly.deploy();
     }
 
+    if (this._gateways.fastly
+      && this._gateways.fastly.updateable()
+      && cfg.links && cfg.links.length) {
+      this._gateways.fastly.init();
+      await this._gateways.fastly.updateLinks(cfg.links, cfg.version);
+    }
+
     if (cfg.deploy) {
       return Object.entries(this._deployers).reduce((p, [name, dep]) => {
         // eslint-disable-next-line no-param-reassign

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -44,7 +44,7 @@ class FastlyGateway {
   async updateLinks(links, version) {
     this.log.info('Updating links on the Gateway');
     const fakeDeployer = new BaseDeployer({
-      links, version, ...this.cfg,
+      links, version, log: this.log,
     });
 
     const versionstrings = fakeDeployer

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -44,7 +44,7 @@ class FastlyGateway {
   async updateLinks(links, version) {
     this.log.info('Updating links on the Gateway');
     const fakeDeployer = new BaseDeployer({
-      links, version,
+      links, version, ...this.cfg,
     });
 
     const versionstrings = fakeDeployer

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -89,6 +89,7 @@ declare local var._version STRING;
 declare local var.atversion STRING;
 declare local var.slashversion STRING;
 declare local var.rest STRING;
+declare local var.fullpath STRING;
 
 set var.version = "";
 set var.rest = "";
@@ -98,6 +99,10 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
   set var.package = re.group.1;
   set var.action = re.group.2;
   set var.version = re.group.3;
+
+  set var.fullpath = "/" + var.package + "/" + var.action + regsub(var.version, "[@_]", "@");
+  
+  set var.version = table.lookup(aliases, var.fullpath, var.version);
 
   set var.rest = re.group.5;
 

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -56,7 +56,7 @@ class FastlyGateway {
         op: 'upsert',
       }));
 
-    await this._fastly.bulkUpdateDictItems(1, 'aliases', ...versionstrings);
+    await this._fastly.bulkUpdateDictItems(undefined, 'aliases', ...versionstrings);
   }
 
   init() {

--- a/src/gateway/FastlyGateway.js
+++ b/src/gateway/FastlyGateway.js
@@ -246,6 +246,11 @@ if (req.url ~ "^/([^/]+)/([^/@_]+)([@_]([^/@_]+)+)?(.*$)") {
         write_only: 'false',
       });
 
+      await this._fastly.writeDictionary(newversion, 'aliases', {
+        name: 'aliases',
+        write_only: 'false',
+      });
+
       // set up health checks
       await Promise.all(this._deployers
         .map((deployer) => ({

--- a/src/template/resolver.js
+++ b/src/template/resolver.js
@@ -143,12 +143,23 @@ class GoogleResolver extends Resolver {
    */
   constructor(req) {
     super(req.headers);
+    this.hostname = req.hostname;
+    if (req.get('x-forwarded-host')) {
+      this.universal = true;
+      this.hostname = req
+        .get('x-forwarded-host')
+        .split(',')
+        .map((h) => h.trim())
+        .pop();
+    }
   }
 
   // eslint-disable-next-line no-unused-vars,class-methods-use-this
   _createActionURL(packageName, actionName, version) {
-    // dummy implementation for testing
-    return new URL(path.join('google:', packageName, actionName, version));
+    if (this.universal) {
+      return new URL(path.join(`https://${this.hostname}`, packageName, `${actionName}${version.replace(/^(.)/, '@$1')}`));
+    }
+    return new URL(path.join(`https://${this.hostname}`, `${packageName}--${actionName}${version.replace(/^(.)/, '_$1').replace(/\./g, '_')}`));
   }
 }
 

--- a/test/fastly-gateway.test.js
+++ b/test/fastly-gateway.test.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+/* eslint-disable no-console */
+const assert = require('assert');
+
+const FastlyGateway = require('../src/gateway/FastlyGateway.js', {});
+
+const gateway = new FastlyGateway({
+  log: {
+    info: console.log,
+  },
+  packageName: 'simple-package',
+  name: 'simple',
+});
+
+let ops = [];
+
+// eslint-disable-next-line no-underscore-dangle
+gateway._fastly = {
+  bulkUpdateDictItems: (_, dict, ...operations) => {
+    ops = operations;
+    assert.equal(dict, 'aliases');
+  },
+};
+
+describe('Unit Tests for Fastly Gateway', () => {
+  beforeEach(() => {
+    ops = [];
+  });
+
+  it('Links a regular major, minor, latest sequence', async () => {
+    await gateway.updateLinks(['major', 'minor', 'latest'], '1.45.0');
+    assert.equal(ops.length, 3);
+    assert.deepStrictEqual(ops[0], {
+      item_key: '/simple-package/simple@v1',
+      item_value: '@1.45.0',
+      op: 'upsert',
+    });
+    assert.deepStrictEqual(ops[1], {
+      item_key: '/simple-package/simple@v1.45',
+      item_value: '@1.45.0',
+      op: 'upsert',
+    });
+    assert.deepStrictEqual(ops[2], {
+      item_key: '/simple-package/simple@latest',
+      item_value: '@1.45.0',
+      op: 'upsert',
+    });
+  });
+
+  it('Links a regular ci sequence', async () => {
+    await gateway.updateLinks(['ci'], 'ci999');
+    assert.equal(ops.length, 1);
+    assert.deepStrictEqual(ops[0], {
+      item_key: '/simple-package/simple@ci',
+      item_value: '@ci999',
+      op: 'upsert',
+    });
+  });
+});

--- a/test/fixtures/simple/index.js
+++ b/test/fixtures/simple/index.js
@@ -27,6 +27,14 @@ module.exports.main = function main(req, context) {
     error: context.env.ERROR,
   });
 
+  const resolve = url.searchParams.get('resolve');
+  if (resolve) {
+    resp.resolve = context.resolver.createURL({
+      name: resolve,
+      version: 'v1',
+    }).href;
+  }
+
   const response = new Response(resp);
   response.headers.set('Surrogate-Key', 'simple');
   response.headers.set('Hey', context.env.HEY);

--- a/test/fixtures/simple/index.js
+++ b/test/fixtures/simple/index.js
@@ -29,10 +29,14 @@ module.exports.main = function main(req, context) {
 
   const resolve = url.searchParams.get('resolve');
   if (resolve) {
-    resp.resolve = context.resolver.createURL({
+    const rurl = context.resolver.createURL({
       name: resolve,
       version: 'v1',
-    }).href;
+    });
+
+    console.log('resolved', rurl);
+
+    resp.resolve = rurl.toString();
   }
 
   const response = new Response(resp);

--- a/test/fixtures/simple/index.js
+++ b/test/fixtures/simple/index.js
@@ -21,11 +21,11 @@ module.exports.main = function main(req, context) {
       status: 503,
     });
   }
-  const resp = JSON.stringify({
+  const resp = {
     url: req.url,
     file: reader(),
     error: context.env.ERROR,
-  });
+  };
 
   const resolve = url.searchParams.get('resolve');
   if (resolve) {
@@ -39,7 +39,7 @@ module.exports.main = function main(req, context) {
     resp.resolve = rurl.toString();
   }
 
-  const response = new Response(resp);
+  const response = new Response(JSON.stringify(resp));
   response.headers.set('Surrogate-Key', 'simple');
   response.headers.set('Hey', context.env.HEY);
   response.headers.set('Foo', context.env.FOO);

--- a/test/gateway.integration.js
+++ b/test/gateway.integration.js
@@ -70,6 +70,9 @@ describe('Gateway Integration Test', () => {
         '--directory', testRoot,
         '--entryFile', 'index.js',
         '--coralogix-token', process.env.CORALOGIX_TOKEN,
+        '-l', 'latest',
+        '-l', 'major',
+        '-l', 'minor',
       ]);
     builder.cfg._logger = new TestLogger();
 

--- a/test/resolver.test.js
+++ b/test/resolver.test.js
@@ -214,26 +214,92 @@ describe('Azure Resolver Tests', () => {
 describe('Google Resolver Tests', () => {
   it('can handle single lock', async () => {
     const resolver = new GoogleResolver({
+      hostname: 'us-central1-helix-225321.cloudfunctions.net',
+      get: () => '',
       headers: {
-        host: 'foo.com',
         'x-ow-version-lock': 'foo=v2',
       },
     });
     assert.equal(
       resolver.createURL({ package: 'bar', name: 'foo', version: 'v1' }).href,
-      'google:/bar/foo/v2',
+      'https://us-central1-helix-225321.cloudfunctions.net/bar--foo_v2',
     );
   });
 
   it('can create url with no version', async () => {
     const resolver = new GoogleResolver({
+      hostname: 'us-central1-helix-225321.cloudfunctions.net',
+      get: () => '',
       headers: {
         host: 'foo.com',
       },
     });
     assert.equal(
       resolver.createURL({ package: 'bar', name: 'foo' }).href,
-      'google:/bar/foo',
+      'https://us-central1-helix-225321.cloudfunctions.net/bar--foo',
+    );
+  });
+});
+
+describe('Google Resolver Tests with single XFH', () => {
+  it('can handle single lock', async () => {
+    const resolver = new GoogleResolver({
+      hostname: 'us-central1-helix-225321.cloudfunctions.net',
+      get: () => 'helix-deploy.anywhere.run',
+      headers: {
+        'x-ow-version-lock': 'foo=v2',
+        'x-forwarded-host': 'helix-deploy.anywhere.run',
+      },
+    });
+    assert.equal(
+      resolver.createURL({ package: 'bar', name: 'foo', version: 'v1' }).href,
+      'https://helix-deploy.anywhere.run/bar/foo@v2',
+    );
+  });
+
+  it('can create url with no version', async () => {
+    const resolver = new GoogleResolver({
+      hostname: 'us-central1-helix-225321.cloudfunctions.net',
+      get: () => 'helix-deploy.anywhere.run',
+      headers: {
+        host: 'foo.com',
+      },
+    });
+    assert.equal(
+      resolver.createURL({ package: 'bar', name: 'foo' }).href,
+      'https://helix-deploy.anywhere.run/bar/foo',
+    );
+  });
+});
+
+describe('Google Resolver Tests with multiple XFH', () => {
+  it('can handle single lock', async () => {
+    const resolver = new GoogleResolver({
+      hostname: 'us-central1-helix-225321.cloudfunctions.net',
+      get: () => 'blog.adobe.com, theblog--adobe.hlx.page,helix-deploy.anywhere.run',
+      headers: {
+        'x-ow-version-lock': 'foo=v2',
+        'x-forwarded-host': 'blog.adobe.com, theblog--adobe.hlx.page,helix-deploy.anywhere.run',
+      },
+    });
+    assert.equal(
+      resolver.createURL({ package: 'bar', name: 'foo', version: 'v1' }).href,
+      'https://helix-deploy.anywhere.run/bar/foo@v2',
+    );
+  });
+
+  it('can create url with no version', async () => {
+    const resolver = new GoogleResolver({
+      hostname: 'us-central1-helix-225321.cloudfunctions.net',
+      get: () => 'blog.adobe.com, theblog--adobe.hlx.page,helix-deploy.anywhere.run',
+      headers: {
+        host: 'foo.com',
+        'x-forwarded-host': 'blog.adobe.com, theblog--adobe.hlx.page,helix-deploy.anywhere.run',
+      },
+    });
+    assert.equal(
+      resolver.createURL({ package: 'bar', name: 'foo' }).href,
+      'https://helix-deploy.anywhere.run/bar/foo',
     );
   });
 });


### PR DESCRIPTION
Implements #175 and adds a working resolution mechanism for Google: it will go back to Universal Runtime as there is no native way to create aliases for Google Cloud Functions.

The Fastly edge dictionary will be updated whenever a service ID and a token are provided (and `-l`), but a full update of the config will only be done if a checkpath has been provided, so that we can safely call `-l` for all our services, but keep the checkpath update to helix-pages.