### PR TITLE
fix(bundler): exclude google storage dependency (included in Google Runtime)

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -69,6 +69,7 @@ module.exports = class Bundler {
         './params.json',
         'aws-sdk',
         '@google-cloud/secret-manager',
+        '@google-cloud/storage',
       ].reduce((obj, ext) => {
         // this makes webpack to ignore the module and just leave it as normal require.
         // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
this should reduce the generated bundle size substantially (from 3.7 MB to 1.4 MB JS for the simple action)
