### PR TITLE
feat: use lambda adapter to validate bundle and execute it

### DIFF
--- a/src/ActionBuilder.js
+++ b/src/ActionBuilder.js
@@ -381,6 +381,10 @@ export default class ActionBuilder {
       for (const bundler of this.bundlers) {
         await bundler.createBundle();
         await bundler.createArchive();
+      }
+    }
+    if (cfg.build || cfg.test !== undefined || cfg.testBundle !== undefined) {
+      for (const bundler of this.bundlers) {
         await bundler.validateBundle();
       }
     }
@@ -408,7 +412,7 @@ export default class ActionBuilder {
       await this.delete();
     }
 
-    if (typeof cfg.test === 'string' || Object.keys(cfg.testParams).length) {
+    if (cfg.test !== undefined || Object.keys(cfg.testParams).length) {
       await this.validateDeployers();
       await this.test();
     }

--- a/src/BaseConfig.js
+++ b/src/BaseConfig.js
@@ -58,6 +58,7 @@ export default class BaseConfig {
       nodeVersion: null,
       deploy: false,
       test: null,
+      testBundle: null,
       testUrl: null,
       testParams: {},
       testHeaders: {},
@@ -173,6 +174,7 @@ export default class BaseConfig {
       .withDelete(argv.delete)
       .withDeploy(argv.deploy)
       .withTest(argv.test)
+      .withTestBundle(argv.testBundle)
       .withTestParams(argv.testParams)
       .withTestHeaders(argv.testHeaders)
       .withTestUrl(argv.testUrl)
@@ -276,6 +278,11 @@ export default class BaseConfig {
 
   withTest(enable) {
     this.test = enable;
+    return this;
+  }
+
+  withTestBundle(enable) {
+    this.testBundle = enable;
     return this;
   }
 
@@ -572,7 +579,7 @@ export default class BaseConfig {
         default: '.',
       })
 
-      .group(['help', 'build', 'deploy', 'test', 'update-package', 'version-link', 'delete'], 'Operation Options')
+      .group(['help', 'build', 'deploy', 'test', 'test-bundle', 'update-package', 'version-link', 'delete'], 'Operation Options')
       .option('build', {
         description: 'Build the deployment package',
         type: 'boolean',
@@ -585,6 +592,10 @@ export default class BaseConfig {
       })
       .option('test', {
         description: 'Invoke action after deployment. Can be relative url or "true"',
+        type: 'string',
+      })
+      .option('test-bundle', {
+        description: 'Invoke bundle after build. Can be relative url or "true". Defaults to the same as --test',
         type: 'string',
       })
       .option('version-link', {

--- a/src/bundler/BaseBundler.js
+++ b/src/bundler/BaseBundler.js
@@ -60,12 +60,15 @@ export default class BaseBundler {
   async validateBundle() {
     const { cfg } = this;
     cfg.log.info('--: validating bundle ...');
-    const result = await validateBundle(cfg.bundle);
+    const result = await validateBundle(cfg.bundle, cfg);
     if (result.error) {
-      cfg.log.error(chalk`{red error:}`, result.error);
       throw Error(`Validation failed: ${result.error}`);
     }
-    cfg.log.info(chalk`{green ok:} bundle can be loaded and has a {grey main()} function.`);
+    if (result.response) {
+      cfg.log.info(chalk`{green ok:} bundle can be loaded and {grey lambda()} function can be executed.`);
+    } else {
+      cfg.log.info(chalk`{green ok:} bundle can be loaded and has a {grey lambda()} function.`);
+    }
   }
 
   async createArchive() {

--- a/src/template/validate-bundle.js
+++ b/src/template/validate-bundle.js
@@ -9,19 +9,54 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-async function run(bundlePath, opts) {
+async function run(bundlePath, cfg) {
   const result = {
+    status: 'ok',
   };
   try {
     const bundle = await import(bundlePath);
-    const main = bundle.default?.main;
-    if (!main || typeof main !== 'function') {
-      throw Error('Action has no main() function.');
+    const lambda = bundle.default?.lambda;
+    if (!lambda || typeof lambda !== 'function') {
+      throw Error('Action has no lambda() function.');
     }
-    if (opts.invoke) {
-      result.response = await main({});
+    const test = cfg.testBundle ?? cfg.test;
+    if (test !== undefined) {
+      const event = {
+        headers: cfg.testHeaders || {},
+        rawPath: `/${cfg.packageName}/${cfg.baseName}/${cfg.version}`,
+        rawQueryString: '',
+        pathParameters: {
+          path: '',
+        },
+        requestContext: {
+          domainName: 'localhost',
+          http: {
+            method: 'get',
+          },
+        },
+      };
+
+      const testUrl = String(test).startsWith('/') ? test : cfg.testUrl;
+      if (testUrl) {
+        const url = new URL(testUrl, 'https://localhost/');
+        event.pathParameters.path = url.pathname.substring(1);
+        event.rawPath += url.pathname;
+        event.rawQueryString = url.searchParams.toString();
+      }
+      const fn = typeof lambda.raw === 'function' ? lambda.raw : lambda;
+      result.response = await fn(event, {
+        invokedFunctionArn: `arn:aws:lambda:us-east-1:118435662149:function:${cfg.packageName}--${cfg.baseName}:${cfg.version}`,
+        getRemainingTimeInMillis: () => 60 * 1000,
+      });
+      if (cfg.verbose) {
+        // eslint-disable-next-line no-console
+        console.log(result.response);
+      }
+      if (result.response.statusCode !== 200) {
+        result.status = 'error';
+        result.error = result.response.statusCode;
+      }
     }
-    result.status = 'ok';
   } catch (e) {
     result.status = 'error';
     result.error = `${e.message}\n${e.stack}`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -155,12 +155,9 @@ export function filterActions(fns, now, {
     ...cleanmajorbyage, ...cleanmajorbycount];
 }
 
-export async function validateBundle(bundlePath, invoke = false) {
+export async function validateBundle(bundlePath, cfg) {
   try {
-    const opts = {
-      invoke,
-    };
-    const child = fork(path.resolve(__dirname, 'template', 'validate-bundle.js'), [bundlePath, JSON.stringify(opts)]);
+    const child = fork(path.resolve(__dirname, 'template', 'validate-bundle.js'), [bundlePath, JSON.stringify(cfg)]);
     const ret = await new Promise((resolve, reject) => {
       child.on('message', resolve);
       child.on('error', reject);

--- a/test/deploy.test.js
+++ b/test/deploy.test.js
@@ -161,7 +161,6 @@ describe('Deploy Test', () => {
       .prepare([
         '--target', 'wsk',
         '--verbose',
-        '--no-build',
         '--test', '/foo',
         '--directory', testRoot,
       ]);
@@ -185,7 +184,6 @@ describe('Deploy Test', () => {
       .prepare([
         '--target', 'wsk',
         '--verbose',
-        '--no-build',
         '--test', '/foo',
         '--test-headers', 'x-foo-bar=test',
         '--directory', testRoot,

--- a/test/fixtures/simple/index.js
+++ b/test/fixtures/simple/index.js
@@ -14,6 +14,9 @@ const reader = require('./helper/read.js');
 
 // eslint-disable-next-line no-unused-vars
 module.exports.main = function main(req, context) {
+  if (req.url.endsWith('/fail')) {
+    throw new Error('internal error');
+  }
   const url = new URL(req.url);
   const chanceoffailure = parseInt(url.searchParams.get('chanceoffailure') || '0', 10);
   if (Math.random() * 100 < chanceoffailure) {

--- a/test/fixtures/web-action/src/index.js
+++ b/test/fixtures/web-action/src/index.js
@@ -9,6 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { Response } = require('@adobe/helix-fetch');
+
 module.exports.main = function main() {
-  return 'ok';
+  return new Response();
 };


### PR DESCRIPTION
This PR improves the _validate bundle_ step by:
1. testing if there is a `lambda` adapter (instead of the openwhisk `main`)
2. invoking the adapter, if either `--test` or `--test-bundle` is given. if the response is not a 200, it fails (similar behaviour as if deployed and requested with `testUrl`)

fixes #353

