### PR TITLE
feat: add AWS lambda authorizers support

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -41,7 +41,9 @@ export default class CLI {
       .env('HLX');
     BaseConfig.yarg(this._yargs);
     PLUGINS.forEach((PluginClass) => PluginClass.Config.yarg(this._yargs));
-    this._yargs.help();
+    this._yargs
+      .wrap(Math.min(120, this._yargs.terminalWidth()))
+      .help();
   }
 
   prepare(args) {

--- a/src/deploy/AWSConfig.js
+++ b/src/deploy/AWSConfig.js
@@ -24,6 +24,8 @@ export default class AWSConfig {
       createRoutes: false,
       lambdaFormat: DEFAULT_LAMBDA_FORMAT,
       parameterMgr: ['system', 'secret'],
+      createAuthorizer: '',
+      attachAuthorizer: '',
     });
   }
 
@@ -33,6 +35,8 @@ export default class AWSConfig {
       .withAWSRole(argv.awsRole)
       .withAWSApi(argv.awsApi)
       .withAWSLambdaFormat(argv.awsLambdaFormat)
+      .withAWSCreateAuthorizer(argv.awsCreateAuthorizer)
+      .withAWSAttachAuthorizer(argv.awsAttachAuthorizer)
       .withAWSCleanUpBuckets(argv.awsCleanupBuckets)
       .withAWSCleanUpIntegrations(argv.awsCleanupIntegrations)
       .withAWSCreateRoutes(argv.awsCreateRoutes)
@@ -79,9 +83,20 @@ export default class AWSConfig {
     return this;
   }
 
+  withAWSCreateAuthorizer(value) {
+    this.createAuthorizer = value;
+    return this;
+  }
+
+  withAWSAttachAuthorizer(value) {
+    this.attachAuthorizer = value;
+    return this;
+  }
+
   static yarg(yargs) {
     return yargs
-      .group(['aws-region', 'aws-api', 'aws-role', 'aws-cleanup-buckets', 'aws-cleanup-integrations', 'aws-create-routes'], 'AWS Deployment Options')
+      .group(['aws-region', 'aws-api', 'aws-role', 'aws-cleanup-buckets', 'aws-cleanup-integrations',
+        'aws-create-routes', 'aws-create-authorizer', 'aws-attach-authorizer'], 'AWS Deployment Options')
       .option('aws-region', {
         description: 'the AWS region to deploy lambda functions to',
         type: 'string',
@@ -112,6 +127,15 @@ export default class AWSConfig {
         description: 'Format to use to create lambda functions (note that all dots (\'.\') will be replaced with underscores.',
         type: 'string',
         default: DEFAULT_LAMBDA_FORMAT,
+      })
+      .option('aws-create-authorizer', {
+        // eslint-disable-next-line no-template-curly-in-string
+        description: 'Authorizer to create or update during linking. The string can contain placeholders (note that all dots (\'.\'). Example "helix-authorizer_${version}".',
+        type: 'string',
+      })
+      .option('aws-attach-authorizer', {
+        description: 'Attach authorizer to linked route.',
+        type: 'string',
       })
       .option('aws-cleanup-buckets', {
         description: 'Cleans up stray temporary S3 buckets',

--- a/src/deploy/AWSConfig.js
+++ b/src/deploy/AWSConfig.js
@@ -96,7 +96,8 @@ export default class AWSConfig {
   static yarg(yargs) {
     return yargs
       .group(['aws-region', 'aws-api', 'aws-role', 'aws-cleanup-buckets', 'aws-cleanup-integrations',
-        'aws-create-routes', 'aws-create-authorizer', 'aws-attach-authorizer'], 'AWS Deployment Options')
+        'aws-create-routes', 'aws-create-authorizer', 'aws-attach-authorizer', 'aws-lambda-format',
+        'aws-parameter-manager'], 'AWS Deployment Options')
       .option('aws-region', {
         description: 'the AWS region to deploy lambda functions to',
         type: 'string',
@@ -129,12 +130,14 @@ export default class AWSConfig {
         default: DEFAULT_LAMBDA_FORMAT,
       })
       .option('aws-create-authorizer', {
-        // eslint-disable-next-line no-template-curly-in-string
-        description: 'Authorizer to create or update during linking. The string can contain placeholders (note that all dots (\'.\'). Example "helix-authorizer_${version}".',
+        description: 'Creates API Gateway authorizer using lambda authorization with this function and the specified name. '
+          + 'The string can contain placeholders (note that all dots (\'.\') are replaced with underscores. '
+          // eslint-disable-next-line no-template-curly-in-string
+          + 'Example: "helix-authorizer_${version}".',
         type: 'string',
       })
       .option('aws-attach-authorizer', {
-        description: 'Attach authorizer to linked route.',
+        description: 'Attach specified authorizer to routes during linking.',
         type: 'string',
       })
       .option('aws-cleanup-buckets', {

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -782,7 +782,7 @@ export default class AWSDeployer extends BaseDeployer {
           Action: 'lambda:InvokeFunction',
           SourceArn: sourceArn,
           Principal: 'apigateway.amazonaws.com',
-          StatementId: crypto.createHash('md5').update(aliasArn + sourceArn).digest('hex'),
+          StatementId: crypto.createHash('sha256').update(aliasArn + sourceArn).digest('hex'),
         }));
         this.log.info(chalk`{green ok:} added invoke permissions for ${sourceArn}`);
       } catch (e) {

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -29,14 +29,14 @@ import {
 
 import {
   ApiGatewayV2Client,
-  CreateApiCommand,
+  CreateApiCommand, CreateAuthorizerCommand,
   CreateIntegrationCommand, CreateRouteCommand,
   CreateStageCommand,
   DeleteIntegrationCommand,
   GetApiCommand,
-  GetApisCommand,
+  GetApisCommand, GetAuthorizersCommand,
   GetIntegrationsCommand, GetRoutesCommand,
-  GetStagesCommand, UpdateRouteCommand,
+  GetStagesCommand, UpdateAuthorizerCommand, UpdateRouteCommand,
 } from '@aws-sdk/client-apigatewayv2';
 
 import { PutParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
@@ -366,6 +366,20 @@ export default class AWSDeployer extends BaseDeployer {
     return routes;
   }
 
+  async fetchAuthorizers(ApiId) {
+    let nextToken;
+    const authorizers = [];
+    do {
+      const res = await this._api.send(new GetAuthorizersCommand({
+        ApiId,
+        NextToken: nextToken,
+      }));
+      authorizers.push(...res.Items);
+      nextToken = res.NextToken;
+    } while (nextToken);
+    return authorizers;
+  }
+
   async createAPI() {
     const { cfg } = this;
     const { ApiId, ApiEndpoint } = await this.initApiId();
@@ -404,8 +418,12 @@ export default class AWSDeployer extends BaseDeployer {
       const { IntegrationId } = integration;
       this.log.info('--: fetching existing routes...');
       const routes = await this.fetchRoutes(ApiId);
-      await this.createOrUpdateRoute(routes, ApiId, IntegrationId, `ANY ${this.functionPath}/{path+}`);
-      await this.createOrUpdateRoute(routes, ApiId, IntegrationId, `ANY ${this.functionPath}`);
+      const routeParams = {
+        ApiId,
+        Target: `integrations/${IntegrationId}`,
+      };
+      await this.createOrUpdateRoute(routes, routeParams, `ANY ${this.functionPath}/{path+}`);
+      await this.createOrUpdateRoute(routes, routeParams, `ANY ${this.functionPath}`);
     }
 
     // setup permissions for entire package.
@@ -581,25 +599,24 @@ export default class AWSDeployer extends BaseDeployer {
     this.log.info(chalk`{green ok}: deleted ${unused.length} unused integrations.`);
   }
 
-  async createOrUpdateRoute(routes, ApiId, IntegrationId, RouteKey) {
+  async createOrUpdateRoute(routes, routeParams, RouteKey) {
     const existing = routes.find((r) => r.RouteKey === RouteKey);
+    const auth = routeParams.AuthorizerId ? chalk` {yellow (${routeParams.AuthorizerId})}` : '';
     if (existing) {
       this.log.info(chalk`--: updating route for: {blue ${existing.RouteKey}}...`);
       const res = await this._api.send(new UpdateRouteCommand({
-        ApiId,
-        RouteId: existing.RouteId,
+        ...routeParams,
         RouteKey,
-        Target: `integrations/${IntegrationId}`,
+        RouteId: existing.RouteId,
       }));
-      this.log.info(chalk`{green ok}: updated route for: {blue ${res.RouteKey}}`);
+      this.log.info(chalk`{green ok}: updated route for: {blue ${res.RouteKey}}${auth}`);
     } else {
       this.log.info(chalk`--: creating route for: {blue ${RouteKey}}...`);
       const res = await this._api.send(new CreateRouteCommand({
-        ApiId,
+        ...routeParams,
         RouteKey,
-        Target: `integrations/${IntegrationId}`,
       }));
-      this.log.info(chalk`{green ok}: created route for: {blue ${res.RouteKey}}`);
+      this.log.info(chalk`{green ok}: created route for: {blue ${res.RouteKey}}${auth}`);
     }
   }
 
@@ -609,20 +626,22 @@ export default class AWSDeployer extends BaseDeployer {
         FunctionName: functionName,
         Name: name,
       }));
-      this.log.info(chalk`--: updating alias for: {blue ${name}}...`);
+      this.log.info(chalk`--: updating alias {blue ${name}}...`);
       await this._lambda.send(new UpdateAliasCommand({
         FunctionName: functionName,
         Name: name,
         FunctionVersion: functionVersion,
       }));
+      this.log.info(chalk`{green ok:} updated alias {blue ${name}} to version {yellow ${functionVersion}}.`);
     } catch (e) {
       if (e.name === 'ResourceNotFoundException') {
-        this.log.info(chalk`--: creating alias for: {blue ${name}}...`);
+        this.log.info(chalk`--: creating alias {blue ${name}}...`);
         await this._lambda.send(new CreateAliasCommand({
           FunctionName: functionName,
           Name: name,
           FunctionVersion: functionVersion,
         }));
+        this.log.info(chalk`{green ok:} created alias {blue ${name}} for version {yellow ${functionVersion}}.`);
       } else {
         this.log.error(`Unable to verify existence of Lambda alias ${name}`);
         throw e;
@@ -673,16 +692,33 @@ export default class AWSDeployer extends BaseDeployer {
     const { IntegrationId } = integration;
 
     // get all the routes
-    this.log.info(chalk`--: patching routes ...`);
+    this.log.info(chalk`--: fetching routes ...`);
     const routes = await this.fetchRoutes(ApiId);
+    const routeParams = {
+      ApiId,
+      Target: `integrations/${IntegrationId}`,
+      AuthorizerId: undefined,
+      AuthorizationType: 'NONE',
+    };
+    if (this._cfg.attachAuthorizer) {
+      this.log.info(chalk`--: fetching authorizers...`);
+      const authorizers = await this.fetchAuthorizers(ApiId);
+      const authorizer = authorizers.find((info) => info.Name === this._cfg.attachAuthorizer);
+      if (!authorizer) {
+        throw Error(`Specified authorizer ${this._cfg.attachAuthorizer} does not exist in api ${ApiId}.`);
+      }
+      routeParams.AuthorizerId = authorizer.AuthorizerId;
+      routeParams.AuthorizationType = 'CUSTOM';
+      this.log.info(chalk`{green ok:} configuring routes with authorizer {blue ${this._cfg.attachAuthorizer}} {yellow ${authorizer.AuthorizerId}}`);
+    }
 
     // create routes for each symlink
     const sfx = this.getLinkVersions();
 
     for (const suffix of sfx) {
       // check if route already exists
-      await this.createOrUpdateRoute(routes, ApiId, IntegrationId, `ANY /${cfg.packageName}/${cfg.baseName}/${suffix}`);
-      await this.createOrUpdateRoute(routes, ApiId, IntegrationId, `ANY /${cfg.packageName}/${cfg.baseName}/${suffix}/{path+}`);
+      await this.createOrUpdateRoute(routes, routeParams, `ANY /${cfg.packageName}/${cfg.baseName}/${suffix}`);
+      await this.createOrUpdateRoute(routes, routeParams, `ANY /${cfg.packageName}/${cfg.baseName}/${suffix}/{path+}`);
 
       // create or update alias
       await this.createOrUpdateAlias(suffix.replace('.', '_'), functionName, incrementalVersion);
@@ -690,6 +726,68 @@ export default class AWSDeployer extends BaseDeployer {
 
     if (cleanup) {
       await this.cleanUpIntegrations(functionName);
+    }
+
+    await this.updateAuthorizers(ApiId, functionName, aliasArn);
+  }
+
+  async updateAuthorizers(ApiId, functionName, aliasArn) {
+    const cfg = this._cfg;
+    if (!cfg.createAuthorizer) {
+      return;
+    }
+
+    const AUTH_URI_PREFIX = `arn:aws:apigateway:${cfg.region}:lambda:path/2015-03-31/functions/`;
+    const accountId = aliasArn.split(':')[4];
+    this.log.info(chalk`--: patching authorizers...`);
+    const authorizers = await this.fetchAuthorizers(ApiId);
+    const versions = this.getLinkVersions();
+    for (const version of versions) {
+      const props = {
+        ...this.cfg,
+        ...this.cfg.properties,
+        // overwrite version with link name
+        version,
+      };
+      const authorizerName = ActionBuilder.substitute(cfg.createAuthorizer, props).replace(/\./g, '_');
+      const existing = authorizers.find((info) => info.Name === authorizerName) || {};
+      let { AuthorizerId } = existing;
+      if (AuthorizerId) {
+        const res = await this._api.send(new UpdateAuthorizerCommand({
+          ApiId,
+          AuthorizerId,
+          AuthorizerUri: `${AUTH_URI_PREFIX}${aliasArn}/invocations`,
+        }));
+        this.log.info(chalk`{green ok}: updated authorizer: {blue ${res.Name}}`);
+      } else {
+        const res = await this._api.send(new CreateAuthorizerCommand({
+          ApiId,
+          AuthorizerPayloadFormatVersion: '2.0',
+          AuthorizerType: 'REQUEST',
+          AuthorizerUri: `${AUTH_URI_PREFIX}${aliasArn}/invocations`,
+          AuthorizerResultTtlInSeconds: 0,
+          EnableSimpleResponses: true,
+          IdentitySource: ['$request.header.Authorization'],
+          Name: authorizerName,
+        }));
+        AuthorizerId = res.AuthorizerId;
+        this.log.info(chalk`{green ok}: created authorizer: {blue ${res.Name}}`);
+      }
+
+      // add permission to alias for the API Gateway is allowed to invoke the authorized function
+      try {
+        const sourceArn = `arn:aws:execute-api:${this._cfg.region}:${accountId}:${ApiId}/authorizers/${AuthorizerId}`;
+        await this._lambda.send(new AddPermissionCommand({
+          FunctionName: aliasArn,
+          Action: 'lambda:InvokeFunction',
+          SourceArn: sourceArn,
+          Principal: 'apigateway.amazonaws.com',
+          StatementId: crypto.createHash('md5').update(aliasArn + sourceArn).digest('hex'),
+        }));
+        this.log.info(chalk`{green ok:} added invoke permissions for ${sourceArn}`);
+      } catch (e) {
+        // ignore, most likely the permission already exists
+      }
     }
   }
 

--- a/test/fixtures/simple-authorizer/index.js
+++ b/test/fixtures/simple-authorizer/index.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-disable no-console */
+
+/**
+ * Lambda event handler
+ */
+async function handler(event) {
+  const { authorization } = event.headers;
+  return {
+    isAuthorized: authorization === 'test',
+    context: {
+      key: 'test',
+    },
+  };
+}
+
+module.exports = {
+  lambda: handler,
+  // make helix-deploy happy
+  main: () => {},
+};

--- a/test/fixtures/simple-authorizer/package.json
+++ b/test/fixtures/simple-authorizer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "simple-authorizer",
+  "version": "0.99",
+  "description": "Simple Test Project",
+  "private": true,
+  "license": "Apache-2.0",
+  "main": "index.js",
+  "dependencies": {
+    "@adobe/helix-fetch": "2.0.0"
+  },
+  "wsk": {
+    "namespace": "helix",
+    "name": "simple-package/simple-authorizer@${version}",
+    "adapterFile": "./index.js",
+    "awsCreateAuthorizer": "helix-simple-test-authorizer_${version}"
+  }
+}


### PR DESCRIPTION
adds 2 new options that come in effect when _linking_

`--aws-create-authorizer = my-authorizer_${version}` 
This is specified when deploying the authorizer function and creates authorizers in the API gateway.
It also adds the required invoke permission to the function alias.
this fixes #261 

`--aws-attach-authorizer = my-authorizer_v1`
This is specified when _linking_ a function. the specified authorizer will be attached to the linked routes.
this fixes #260 
