### PR TITLE
fix: fix development server dev params

### DIFF
--- a/src/DevelopmentServer.js
+++ b/src/DevelopmentServer.js
@@ -87,6 +87,11 @@ export default class DevelopmentServer {
     return this;
   }
 
+  withDirectory(value) {
+    this._cwd = value;
+    return this;
+  }
+
   get port() {
     return this._port;
   }
@@ -102,23 +107,33 @@ export default class DevelopmentServer {
     // load the action params params
     let pkgJson = {};
     try {
-      pkgJson = await fse.readJson(path.resolve('package.json'));
+      pkgJson = await fse.readJson(path.resolve(this._cwd, 'package.json'));
     } catch (e) {
       // ignore
     }
     const config = new BaseConfig();
-    if (pkgJson.wsk && pkgJson.wsk['params-file']) {
-      config.withParamsFile(pkgJson.wsk['params-file']);
+    if (pkgJson.wsk) {
+      const withParamsFile = async (file) => {
+        if (!file) {
+          return;
+        }
+        // eslint-disable-next-line no-param-reassign
+        const files = (Array.isArray(file) ? file : [file]).map((f) => path.resolve(this._cwd, f));
+        await Promise.all(files.map(async (f) => {
+          if (await fse.exists(f)) {
+            config.withParamsFile(f);
+          }
+        }));
+      };
+
+      await withParamsFile(pkgJson.wsk?.package?.['params-file']);
+      config.withParams(pkgJson.wsk?.package?.params);
+      await withParamsFile(pkgJson.wsk?.['params-file']);
+      config.withParams(pkgJson.wsk?.params);
+      await withParamsFile(pkgJson.wsk?.dev?.['params-file']);
+      config.withParams(pkgJson.wsk?.dev?.params);
     }
-    if (pkgJson.wsk && pkgJson.wsk.package && pkgJson.wsk.package['params-file']) {
-      config.withParamsFile(pkgJson.wsk.package['params-file']);
-    }
-    if (pkgJson.wsk && pkgJson.wsk['dev-params-file']) {
-      const file = pkgJson.wsk['dev-params-file'];
-      if (await fse.exists(file)) {
-        config.withParamsFile(file);
-      }
-    }
+
     const builder = new ActionBuilder().withConfig(config);
     await builder.validate();
 
@@ -129,7 +144,8 @@ export default class DevelopmentServer {
       './main.js': {
         main: this._main,
       },
-      './google-package-params.js': () => (config.params),
+      './google-package-params.js': () => (config.params), // backward compatible
+      './google-secrets.js': () => (config.params),
     });
     this.params = config.params;
     return this;

--- a/src/DevelopmentServer.js
+++ b/src/DevelopmentServer.js
@@ -170,7 +170,9 @@ export default class DevelopmentServer {
       }
     });
     this.app.use(rawBody());
-    this.app.use(addRequestHeader('x-forwarded-host', this._xfh.replace('{port}', this._port)));
+    if (this._xfh) {
+      this.app.use(addRequestHeader('x-forwarded-host', this._xfh.replace('{port}', this._port)));
+    }
     this.app.all('*', this._handler);
   }
 

--- a/test/fixtures/server-test/package.json
+++ b/test/fixtures/server-test/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "simple-project",
+  "version": "1.45.0",
+  "description": "Simple Test Project",
+  "private": true,
+  "wsk": {
+    "namespace": "helix",
+    "name": "simple-package/simple-name@${version}",
+    "params-file": [
+      "test.env"
+    ],
+    "params": {
+      "TEST_PARAM": "foo-param",
+      "TEST_DEFAULT_PARAM": "default"
+    },
+    "package": {
+      "name": "simple-package",
+      "params": {
+        "TEST_PACKAGE_PARAM": "foo-package-param"
+      },
+      "params-file": [
+        "test-package.env"
+      ]
+    },
+    "dev": {
+      "params": {
+        "TEST_DEV_PARAM": "foo-dev-param",
+        "TEST_DEFAULT_PARAM": "dev-default"
+      },
+      "params-file": [
+        "test-dev.env"
+      ]
+    }
+  }
+}

--- a/test/fixtures/server-test/test-dev.env
+++ b/test/fixtures/server-test/test-dev.env
@@ -1,0 +1,1 @@
+TEST_DEV_FILE_PARAM=foo-dev-file

--- a/test/fixtures/server-test/test-package.env
+++ b/test/fixtures/server-test/test-package.env
@@ -1,0 +1,1 @@
+TEST_PACKAGE_FILE_PARAM=foo-package-file

--- a/test/fixtures/server-test/test.env
+++ b/test/fixtures/server-test/test.env
@@ -1,0 +1,1 @@
+TEST_FILE_PARAM=foo-file


### PR DESCRIPTION
fix the params loading:

- package file-params
- package params
- file-param
- params
- dev file-params
- dev-params

the later wins over the earlier. 

example `wsk` in `package.json`:

```json
 "wsk": {
    "params-file": [
      "test.env"
    ],
    "params": {
      "TEST_PARAM": "foo-param",
      "TEST_DEFAULT_PARAM": "default"
    },
    "package": {
      "name": "simple-package",
      "params": {
        "TEST_PACKAGE_PARAM": "foo-package-param"
      },
      "params-file": [
        "test-package.env"
      ]
    },
    "dev": {
      "params": {
        "TEST_DEV_PARAM": "foo-dev-param",
        "TEST_DEFAULT_PARAM": "dev-default"
      },
      "params-file": [
        "test-dev.env"
      ]
    }
```    
