### PR TITLE
fix: add tags to newly created polyfunc bucket

### DIFF
--- a/src/deploy/AWSConfig.js
+++ b/src/deploy/AWSConfig.js
@@ -27,6 +27,7 @@ export default class AWSConfig {
       createAuthorizer: '',
       attachAuthorizer: '',
       identitySources: ['$request.header.Authorization'],
+      deployTemplate: 'helix-deploy-template',
     });
   }
 
@@ -42,7 +43,8 @@ export default class AWSConfig {
       .withAWSCleanUpBuckets(argv.awsCleanupBuckets)
       .withAWSCleanUpIntegrations(argv.awsCleanupIntegrations)
       .withAWSCreateRoutes(argv.awsCreateRoutes)
-      .withAWSParamsManager(argv.awsParameterManager);
+      .withAWSParamsManager(argv.awsParameterManager)
+      .withAWSDeployTemplate(argv.awsDeployTemplate);
   }
 
   withAWSRegion(value) {
@@ -100,11 +102,16 @@ export default class AWSConfig {
     return this;
   }
 
+  withAWSDeployTemplate(value) {
+    this.deployTemplate = value;
+    return this;
+  }
+
   static yarg(yargs) {
     return yargs
       .group(['aws-region', 'aws-api', 'aws-role', 'aws-cleanup-buckets', 'aws-cleanup-integrations',
         'aws-create-routes', 'aws-create-authorizer', 'aws-attach-authorizer', 'aws-lambda-format',
-        'aws-parameter-manager'], 'AWS Deployment Options')
+        'aws-parameter-manager', 'aws-deploy-template'], 'AWS Deployment Options')
       .option('aws-region', {
         description: 'the AWS region to deploy lambda functions to',
         type: 'string',
@@ -162,6 +169,11 @@ export default class AWSConfig {
         description: 'Cleans up unused integrations',
         type: 'boolean',
         default: false,
+      })
+      .option('aws-deploy-template', {
+        description: 'Name of the deploy S3 bucket template to use',
+        type: 'string',
+        default: 'helix-deploy-template',
       });
   }
 }

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -51,11 +51,6 @@ import BaseDeployer from './BaseDeployer.js';
 import ActionBuilder from '../ActionBuilder.js';
 import AWSConfig from './AWSConfig.js';
 
-/**
- * Name of the deploy template bucket
- */
-const TEMPLATE_BUCKET = 'helix-deploy-template';
-
 export default class AWSDeployer extends BaseDeployer {
   constructor(baseConfig, config) {
     super(baseConfig);
@@ -158,11 +153,16 @@ export default class AWSDeployer extends BaseDeployer {
     }));
     this.log.info(chalk`{green ok:} bucket ${data.Location} created`);
 
+    const { deployTemplate } = this._cfg;
+    if (!deployTemplate) {
+      return;
+    }
+
     let tags;
     try {
       // Obtain tags from template bucket
       const result = await this._s3.send(new GetBucketTaggingCommand({
-        Bucket: TEMPLATE_BUCKET,
+        Bucket: deployTemplate,
       }));
       tags = result.TagSet;
     } catch (e) {

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -13,8 +13,9 @@
 import chalk from 'chalk-template';
 import {
   CreateBucketCommand, DeleteBucketCommand, DeleteObjectCommand, DeleteObjectsCommand,
-  ListBucketsCommand,
+  GetBucketTaggingCommand, ListBucketsCommand,
   ListObjectsV2Command, PutObjectCommand,
+  PutPublicAccessBlockCommand, PutBucketTaggingCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
 
@@ -49,6 +50,11 @@ import crypto from 'crypto';
 import BaseDeployer from './BaseDeployer.js';
 import ActionBuilder from '../ActionBuilder.js';
 import AWSConfig from './AWSConfig.js';
+
+/**
+ * Name of the deploy template bucket
+ */
+const TEMPLATE_BUCKET = 'helix-deploy-template';
 
 export default class AWSDeployer extends BaseDeployer {
   constructor(baseConfig, config) {
@@ -151,6 +157,39 @@ export default class AWSDeployer extends BaseDeployer {
       Bucket: this._bucket,
     }));
     this.log.info(chalk`{green ok:} bucket ${data.Location} created`);
+
+    let tags;
+    try {
+      // Obtain tags from template bucket
+      const result = await this._s3.send(new GetBucketTaggingCommand({
+        Bucket: TEMPLATE_BUCKET,
+      }));
+      tags = result.TagSet;
+    } catch (e) {
+      this.log.warn(`Unable to obtain default tags from template bucket: ${this.bucket}`, e);
+      return;
+    }
+
+    // Block public access
+    await this._s3.send(new PutPublicAccessBlockCommand({
+      Bucket: this._bucket,
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        IgnorePublicAcls: true,
+        BlockPublicPolicy: true,
+        RestrictPublicBuckets: true,
+      },
+    }));
+    this.log.info(chalk`{green ok:} bucket ${data.Location} hidden from public`);
+
+    // Put required tags
+    await this._s3.send(new PutBucketTaggingCommand({
+      Bucket: this._bucket,
+      Tagging: {
+        TagSet: tags,
+      },
+    }));
+    this.log.info(chalk`{green ok:} added tags to bucket ${data.Location}`);
   }
 
   async uploadZIP() {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -439,6 +439,7 @@ describe('CLI Test', () => {
       createAuthorizer: undefined,
       attachAuthorizer: undefined,
       identitySources: ['$request.header.Authorization'],
+      deployTemplate: 'helix-deploy-template',
     });
   });
 });


### PR DESCRIPTION
fix #243

Uses template bucket `helix-deploy-template` by default, logs a warning if not found but continues working.