### PR TITLE
chore: disable gateway tests

### DIFF
--- a/test/fastly-gateway.test.js
+++ b/test/fastly-gateway.test.js
@@ -37,7 +37,7 @@ gateway._fastly = {
   discard: () => true,
 };
 
-describe('Unit Tests for Fastly Gateway', () => {
+describe.skip('Unit Tests for Fastly Gateway', () => {
   beforeEach(() => {
     ops = [];
   });


### PR DESCRIPTION
somehow the gateway tests, create a VLC version that uses openwhisk as backend, which then fails and alerts the monitors.