### PR TITLE
feat: support invocation id

### DIFF
--- a/src/DevelopmentServer.js
+++ b/src/DevelopmentServer.js
@@ -9,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import crypto from 'crypto';
 import fse from 'fs-extra';
 import path from 'path';
 import express from 'express';
@@ -161,6 +162,7 @@ export default class DevelopmentServer {
         rawQueryString,
       };
       const context = {
+        awsRequestId: crypto.randomUUID(),
         invokedFunctionArn: `arn:aws:lambda:${region}:${accountId}:function:${config.name}:${config.version}`,
         getRemainingTimeInMillis: () => 60000,
       };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -164,6 +164,25 @@ describe('Server Test', () => {
     await server.stop();
   });
 
+  it('it provides an invocation id', async () => {
+    // eslint-disable-next-line arrow-body-style
+    const main = async (req, context) => {
+      return new Response(`id: ${context.invocation.id}`);
+    };
+
+    const server = new DevelopmentServer(main).withPort(0);
+    await server.init();
+    await server.start();
+
+    const res = await fetch(`http://localhost:${server.server.address().port}/`, {
+      headers: {
+        'x-http-method': 'RUN',
+      },
+    });
+    assert.match(await res.text(), /id: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/);
+    await server.stop();
+  });
+
   it('it can return binary content', async () => {
     // eslint-disable-next-line arrow-body-style
     const main = async (req) => {


### PR DESCRIPTION
... which can then be used in log statements, even when using `$ npm run start` with `nodemon`