### PR TITLE
fix(cli) Fixes a hang on completion when deploying to Fastly Edge Com…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,4 +13,6 @@
  */
 import CLI from './cli.js';
 
-new CLI().run(process.argv.slice(2));
+await new CLI().run(process.argv.slice(2));
+
+process.exit(process.exitCode);


### PR DESCRIPTION
## Description

When deploying to Fastly c@e the command works but it doesn't exit the process on completion.

## Related Issue

#587 

## Motivation and Context

Every time I run hedy to deploy something to Fastly c@e I have to check when it's finished and then press Ctrl-C to get my command prompt back. That's clearly not ideal.
Besides, this will break any shell scripts that want to do this.

## How Has This Been Tested?

I have just tested it on the commandline. Since it adds a process.exit() it's not really unit-testable.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
