### PR TITLE
fix(fastly) Close fastly client after deploy

### DIFF
--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -153,6 +153,8 @@ service_id = ""
       this.log.debug(`--: updating gateway backend: ${host}`);
       await this._fastly.writeBackend(version, 'gateway', backend);
     }, true);
+
+    await this._fastly.discard();
   }
 
   async updatePackage() {
@@ -172,7 +174,7 @@ service_id = ""
     await this._fastly.updateDictItem(undefined, 'secrets', '_token', this.cfg.packageToken);
     await this._fastly.updateDictItem(undefined, 'secrets', '_package', `https://${this._cfg.fastlyGateway}/${this.cfg.packageName}/`);
 
-    this._fastly.discard();
+    await this._fastly.discard();
   }
 
   get fullFunctionName() {


### PR DESCRIPTION
## Description

And properly close it after updatePackage.

This fixes a 5-minute hang that happens after deployment.

## Related Issue

Fixes: #587

## Motivation and Context

Every time I run hedy to deploy something to Fastly c@e I have to check when it's finished and then press Ctrl-C to get my command prompt back, unless I wait 5 minutes. That's clearly not ideal.

## How Has This Been Tested?

It has been tested with Fastly Compute@Edge.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
