### PR TITLE
fix(cloudflare): Do not make absolute path relative

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-deploy",
-  "version": "9.3.16",
+  "version": "9.3.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-deploy",
-      "version": "9.3.16",
+      "version": "9.3.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fastly-native-promises": "3.0.6",

--- a/src/deploy/CloudflareDeployer.js
+++ b/src/deploy/CloudflareDeployer.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import path from 'path';
 import fs from 'fs';
 import FormData from 'form-data';
 import BaseDeployer from './BaseDeployer.js';
@@ -43,7 +42,7 @@ export default class CloudflareDeployer extends BaseDeployer {
   }
 
   async deploy() {
-    const body = fs.readFileSync(path.relative(this.cfg.cwd, this.cfg.edgeBundle));
+    const body = fs.readFileSync(this.cfg.edgeBundle);
     const { id } = await this.createKVNamespace(`${this.cfg.packageName}--secrets`);
 
     const metadata = {


### PR DESCRIPTION
## Description

The path to the Javascript file to be deployed was made relative to a directory different than the current directory, which cause the file read to fail. The path is already absolute so we don't need to process it.

## Related Issue

Fixes: #619

## Motivation and Context

It makes a failure scenario of deploying to Cloudflare work.

## How Has This Been Tested?

It has been tested by making real deployments to Cloudflare Workers.
## Types of changes

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
