### PR TITLE
fix(fastly): do not fork the process, instead use fastly's own CLI backend

### DIFF
--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -76,15 +76,14 @@ name = "${this.cfg.packageName}"
 service_id = ""
     `);
 
+    const {
+      input,
+      output,
+      wasmEngine,
+    } = await parseInputs([this.cfg.edgeBundle, path.resolve(bundleDir, 'bin', 'main.wasm')]);
+
     return new Promise((resolve, reject) => {
       this.log.debug('--: creating WASM bundle of script and interpreter');
-
-      const {
-        input,
-        output,
-        wasmEngine,
-      } = parseInputs([this.cfg.edgeBundle, 'bin/main.wasm']);
-      this.log.info(`--: compiling ${input} to ${output}`);
       compileApplicationToWasm(input, output, wasmEngine, false, false)
         .then(async () => {
           const file = path.resolve(bundleDir, 'fastly-bundle.tar.gz');

--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -77,7 +77,7 @@ service_id = ""
 
     return new Promise((resolve, reject) => {
       this.log.debug('--: creating WASM bundle of script and interpreter');
-      compileApplicationToWasm(this.cfg.cfg.edgeBundle, 'bin/main.wasm')
+      compileApplicationToWasm(this.cfg.edgeBundle, 'bin/main.wasm')
         .then(async () => {
           const file = path.resolve(bundleDir, 'fastly-bundle.tar.gz');
           this.log.debug(chalk`{green ok:} created WASM bundle of script and interpreter in ${bundleDir}/bin/main.wasm`);

--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -14,7 +14,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import tar from 'tar';
 import Fastly from '@adobe/fastly-native-promises';
-import compileApplicationToWasm from '@fastly/js-compute/src/compileApplicationToWasm.js';
+import { compileApplicationToWasm } from '@fastly/js-compute/src/compileApplicationToWasm.js';
 import BaseDeployer from './BaseDeployer.js';
 import ComputeAtEdgeConfig from './ComputeAtEdgeConfig.js';
 

--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -15,6 +15,7 @@ import fs from 'fs/promises';
 import tar from 'tar';
 import Fastly from '@adobe/fastly-native-promises';
 import { compileApplicationToWasm } from '@fastly/js-compute/src/compileApplicationToWasm.js';
+import { parseInputs } from '@fastly/js-compute/src/parseInputs.js';
 import BaseDeployer from './BaseDeployer.js';
 import ComputeAtEdgeConfig from './ComputeAtEdgeConfig.js';
 
@@ -77,7 +78,13 @@ service_id = ""
 
     return new Promise((resolve, reject) => {
       this.log.debug('--: creating WASM bundle of script and interpreter');
-      compileApplicationToWasm(this.cfg.edgeBundle, 'bin/main.wasm')
+
+      const {
+        input,
+        output,
+        wasmEngine,
+      } = parseInputs([this.cfg.edgeBundle, 'bin/main.wasm']);
+      compileApplicationToWasm(input, output, wasmEngine, false, false)
         .then(async () => {
           const file = path.resolve(bundleDir, 'fastly-bundle.tar.gz');
           this.log.debug(chalk`{green ok:} created WASM bundle of script and interpreter in ${bundleDir}/bin/main.wasm`);

--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -98,6 +98,7 @@ service_id = ""
           this.log.debug(chalk`{green ok:} created tar file in ${bundleDir}/fastly-bundle.tar.gz`);
           resolve(fs.readFile(file));
         })
+        // c8 ignore next 3
         .catch((err) => {
           reject(err);
         });

--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -84,6 +84,7 @@ service_id = ""
         output,
         wasmEngine,
       } = parseInputs([this.cfg.edgeBundle, 'bin/main.wasm']);
+      this.log(`--: compiling ${input} to ${output}`);
       compileApplicationToWasm(input, output, wasmEngine, false, false)
         .then(async () => {
           const file = path.resolve(bundleDir, 'fastly-bundle.tar.gz');

--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -84,7 +84,7 @@ service_id = ""
         output,
         wasmEngine,
       } = parseInputs([this.cfg.edgeBundle, 'bin/main.wasm']);
-      this.log(`--: compiling ${input} to ${output}`);
+      this.log.debug(`--: compiling ${input} to ${output}`);
       compileApplicationToWasm(input, output, wasmEngine, false, false)
         .then(async () => {
           const file = path.resolve(bundleDir, 'fastly-bundle.tar.gz');

--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -84,7 +84,7 @@ service_id = ""
         output,
         wasmEngine,
       } = parseInputs([this.cfg.edgeBundle, 'bin/main.wasm']);
-      this.log.debug(`--: compiling ${input} to ${output}`);
+      this.log.info(`--: compiling ${input} to ${output}`);
       compileApplicationToWasm(input, output, wasmEngine, false, false)
         .then(async () => {
           const file = path.resolve(bundleDir, 'fastly-bundle.tar.gz');


### PR DESCRIPTION
We've been plagued by build failures in https://app.circleci.com/pipelines/github/adobe/helix-rum-collector?branch=renovate-adobe-fixes
due to a failed resolution of the `js-compute-runtime-cli.js` file.

The resolution would work in tests here, because `hedy` was the only dependency, and it would also work in projects that had a conflicting
version of `@fastly/js-compute` installed (because `npm install` would then keep one copy right below `node_modules/@adobe/helix-deploy/node_modules`)

But in scenarios where there was a clean install, `js-compute` would be underneath `node_modules/@fastly/js-compute` and our `ComputeAtEdgeDeployer` would
unsuccessfully try to load the script from its own `node_modules`.

Instead of trying to build a fallback mechanism, the fix in this PR will import the backend of Fastly's own CLI as an ESM module and invoke it directly. This
has the advantage of getting `node`'s built-in module resolution, but it comes with the disadvantage that `compileApplicationToWasm` likes to `process.exit()`
if things go wrong. This makes for much less convenient error handling.
