### PR TITLE
Creating consistency for context.suffix over all adapters - others on…

### DIFF
--- a/src/template/fastly-adapter.js
+++ b/src/template/fastly-adapter.js
@@ -51,7 +51,7 @@ async function handler(event) {
     const context = {
       resolver: null,
       pathInfo: {
-        suffix: request.url.match(/^https?:\/\/[^\/]+([^\?]+)/)[1],
+        suffix: request.url.match(/^https?:\/\/[^/]+([^?]+)/)[1],
       },
       runtime: {
         name: 'compute-at-edge',

--- a/src/template/fastly-adapter.js
+++ b/src/template/fastly-adapter.js
@@ -51,7 +51,7 @@ async function handler(event) {
     const context = {
       resolver: null,
       pathInfo: {
-        suffix: request.url.replace(/\?.*/, ''),
+        suffix: request.url.match(/^https?:\/\/[^\/]+([^\?]+)/)[1],
       },
       runtime: {
         name: 'compute-at-edge',


### PR DESCRIPTION
Creating consistency for context.suffix over all adapters - others only contain the request path, not the fully qualified URL.

## Description

Changing a regex to only have the URL path and not the protocol + host

## Motivation and Context

Consistency over all adapters

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
