### PR TITLE
fix(fastly): guard against missing gateway name

### DIFF
--- a/src/deploy/ComputeAtEdgeDeployer.js
+++ b/src/deploy/ComputeAtEdgeDeployer.js
@@ -137,8 +137,10 @@ service_id = ""
         max_conn: 200,
         use_ssl: true,
       };
-      this.log.debug(`--: updating gateway backend: ${host}`);
-      await this._fastly.writeBackend(version, 'gateway', backend);
+      if (host) {
+        this.log.debug(`--: updating gateway backend: ${host}`);
+        await this._fastly.writeBackend(version, 'gateway', backend);
+      }
     }, true);
 
     await this._fastly.discard();


### PR DESCRIPTION
when no `--fastly-gateway` parameter has been set, then deploying to Fastly Compute fails

```
--: uploading package to fastly, service version 5
--: creating secrets dictionary
--: updating gateway backend:
error: Fastly Compute@Edge - Address 'address' is not a valid IPv4, IPv6 or hostname
error: aborted due to errors during deploy
```

this is caused by a server-side validation on the fastly end. The fix will make sure host
is set before trying to update the gateway host.
