### PR TITLE
feat: allow addition of webpack plugins. fixes #641

### DIFF
--- a/src/bundler/WebpackBundler.js
+++ b/src/bundler/WebpackBundler.js
@@ -100,6 +100,15 @@ export default class WebpackBundler extends BaseBundler {
     if (cfg.progressHandler) {
       opts.plugins.push(new webpack.ProgressPlugin(cfg.progressHandler));
     }
+
+    const customizePath = path.join(cfg.cwd, 'hlx.webpack.customize.js');
+    if (await fse.pathExists(customizePath)) {
+      cfg.log.info(`--: Using custom webpack config from ${customizePath}`);
+      const customize = await import(customizePath);
+      if (customize.extraPlugins && typeof customize.extraPlugins === 'function') {
+        opts.plugins.push(...customize.extraPlugins(cfg, opts));
+      }
+    }
     return opts;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is a fairly simple extension point that depends upon a statically named file hlx.webpack.customize.js. This is expected to export a function named extraPlugins that accepts the hedy config and the webpack config and returns an array of plugins.

This is an alternative to #642 which provides a narrower extension point.

## Related Issue

#641 

## Motivation and Context

There are challenges with using opentelemetry-js and webpack-bundled modules. It is possible to work around these challenges using a webpack plugin but doing so with hedy is not possible today.

## How Has This Been Tested?

I've applied this patch to a local project.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
