### PR TITLE
feat: support environment variable interpolation in config using syntax ${env.VAR_NAME}. fixes #644

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,23 @@ In order to automatically use the version of the `package.json` use:
 > **Note**: the version is internally taken from the `pkgVersion` variable, so it can be overridden with
  the `--pkgVersion` argument, in case it should be deployed differently.
 
+### Environment Variable Interpolation in Arguments
+
+In addition to the `${version}` token described above, arguments will be interpolated using environment variables where the variables exist. For example, given an environment variable named `PROBOT_DOCKER_VERSION` is set to `latest`, this configuration:
+
+```json
+{
+...
+  "wsk": {
+    ...
+    "docker": "adobe/probot-ow-nodejs8:${env.PROBOT_DOCKER_VERSION}"
+  },
+...
+}
+```
+
+Will result in the materialized value of the `docker` argument to be set to `adobe/probot-ow-nodejs8:latest`.
+
 #### Automatically create semantic versioning sequence actions
 
 By using the `--version-link` (`-l`), the bulider can create action sequences _linking_ to the deployed version,


### PR DESCRIPTION
## Description

Interpolates environment variables in parsed configuration using yargs middleware. Once the config is read from the combination of the CLI arguments, package.json and environment variables, the resulting object is updated replacing `${env.VARIABLE_NAME}` with the value of `process.env.VARIABLE_NAME` (assuming such a variable exists).

The current use of `${version}` in the `name` config property is not impacted since that is not prefixed with `env.`.

## Related Issue

#644

## Motivation and Context

See #644

## How Has This Been Tested?

Local testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
