### PR TITLE
feat: add support for custom AWS tags which are set on the deployed Lambda. Fixes #651

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ AWS Deployment Options
       --aws-log-format            The lambda log format. Can be either "JSON" or "Text". [string]
       --aws-layers                List of layers ARNs to attach to the lambda function.  [array]
       --aws-tracing-mode          The lambda tracing mode. Can be either "Active" or "PassThrough". [string]
-      --aws-extra-permissions     A list fo additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>. [array]
+      --aws-extra-permissions     A list of additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>. [array]
+      --aws-tags                  A list of additional tags to attach to the lambda function in the form key=value. To remove a tag, use key= (i.e. without a value).[array]
 
 Google Deployment Options
       --google-project-id  the Google Cloud project to deploy to. Optional when the key file is a JSON file  [string] [default: ""]

--- a/src/deploy/AWSConfig.js
+++ b/src/deploy/AWSConfig.js
@@ -34,6 +34,7 @@ export default class AWSConfig {
       layers: undefined,
       tracingMode: undefined,
       extraPermissions: undefined,
+      tags: undefined,
     });
   }
 
@@ -56,7 +57,8 @@ export default class AWSConfig {
       .withAWSLogFormat(argv.awsLogFormat)
       .withAWSLayers(argv.awsLayers)
       .withAWSTracingMode(argv.awsTracingMode)
-      .withAWSExtraPermissions(argv.awsExtraPermissions);
+      .withAWSExtraPermissions(argv.awsExtraPermissions)
+      .withAWSTags(argv.awsTags);
   }
 
   withAWSRegion(value) {
@@ -152,13 +154,21 @@ export default class AWSConfig {
     return this;
   }
 
+  withAWSTags(value) {
+    if (value && !Array.isArray(value)) {
+      throw new Error('awsTags must be an array');
+    }
+    this.tags = value;
+    return this;
+  }
+
   static yarg(yargs) {
     return yargs
       .group(['aws-region', 'aws-api', 'aws-role', 'aws-cleanup-buckets', 'aws-cleanup-integrations',
         'aws-cleanup-versions', 'aws-create-routes', 'aws-create-authorizer', 'aws-attach-authorizer',
         'aws-lambda-format', 'aws-parameter-manager', 'aws-deploy-template', 'aws-arch', 'aws-update-secrets',
         'aws-deploy-bucket', 'aws-identity-source', 'aws-log-format', 'aws-layers',
-        'aws-tracing-mode', 'aws-extra-permissions'], 'AWS Deployment Options')
+        'aws-tracing-mode', 'aws-extra-permissions', 'aws-tags'], 'AWS Deployment Options')
       .option('aws-region', {
         description: 'the AWS region to deploy lambda functions to',
         type: 'string',
@@ -245,8 +255,13 @@ export default class AWSConfig {
         type: 'string',
       })
       .option('aws-extra-permissions', {
-        description: 'A list fo additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>.',
+        description: 'A list of additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>.',
         type: 'string',
+        array: true,
+      })
+      .option('aws-tags', {
+        description: 'A list of additional tags to attach to the lambda function in the form key=value. To remove a tag, use key= (i.e. without a value).',
+        type: 'array',
         array: true,
       });
   }

--- a/test/aws.deployer.test.js
+++ b/test/aws.deployer.test.js
@@ -174,4 +174,40 @@ describe('AWS Deployer Test', () => {
     await aws.init();
     await aws.cleanUpVersions();
   });
+
+  it('correctly returns an empty object when no tags', async () => {
+    const cfg = new BaseConfig()
+      .withVersion('1.18.2')
+      // eslint-disable-next-line no-template-curly-in-string
+      .withName('/helix-services/static@${version}');
+    const awsCfg = new AWSConfig();
+    const builder = new ActionBuilder().withConfig(cfg);
+    await builder.validate();
+    const aws = new AWSDeployer(cfg, awsCfg);
+
+    assert.deepStrictEqual(aws.additionalTags, {});
+  });
+
+  it('correctly transforms tags into an object', async () => {
+    const cfg = new BaseConfig()
+      .withVersion('1.18.2')
+      // eslint-disable-next-line no-template-curly-in-string
+      .withName('/helix-services/static@${version}');
+    const awsCfg = new AWSConfig().withAWSTags(['foo=bar', 'baz=qux=quux']);
+    const builder = new ActionBuilder().withConfig(cfg);
+    await builder.validate();
+    const aws = new AWSDeployer(cfg, awsCfg);
+
+    assert.deepStrictEqual(aws.additionalTags, {
+      foo: 'bar',
+      baz: 'qux=quux',
+    });
+  });
+
+  it('creates an error if awsTags is set as an object', async () => {
+    assert.throws(() => new AWSConfig().withAWSTags({ foo: 'bar' }), {
+      name: 'Error',
+      message: 'awsTags must be an array',
+    });
+  });
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -446,6 +446,7 @@ describe('CLI Test', () => {
       extraPermissions: undefined,
       layers: undefined,
       logFormat: undefined,
+      tags: undefined,
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add an `--aws-tags` option to the CLI. This is an array of key value pairs, delimited by `=` (similar to the AWS CLI).

## Related Issue

#651 

## Motivation and Context

Primarily need this for cost tracking at scale.

## How Has This Been Tested?

Manual testing. Added some unit tests to cover the configuration cases as well.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
