### PR TITLE
fix: do not stop query string at question mark

### DIFF
--- a/src/DevelopmentServer.js
+++ b/src/DevelopmentServer.js
@@ -150,7 +150,8 @@ export default class DevelopmentServer {
       },
     });
     this._handler = async (req, res) => {
-      const [rawPath, rawQueryString = ''] = req.originalUrl.split('?');
+      const [rawPath, ...rest] = req.originalUrl.split('?');
+      const rawQueryString = rest.join('?');
       const method = req.headers['x-http-method'] || req.method;
       const event = {
         body: req.rawBody,

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -148,6 +148,21 @@ describe('Server Test', () => {
     await server.stop();
   });
 
+  it('it can see a query string that itself contains a question mark', async () => {
+    // eslint-disable-next-line arrow-body-style
+    const main = async (req) => {
+      return new Response(`url: ${new URL(req.url).searchParams.get('url')}`);
+    };
+
+    const server = new DevelopmentServer(main).withPort(0);
+    await server.init();
+    await server.start();
+
+    const res = await fetch(`http://localhost:${server.server.address().port}/?url=http://localhost/?a=1`);
+    assert.strictEqual(await res.text(), 'url: http://localhost/?a=1');
+    await server.stop();
+  });
+
   it('it can see the suffix in the pathInfo', async () => {
     // eslint-disable-next-line arrow-body-style
     const main = async (_, ctx) => {


### PR DESCRIPTION
noticed that when I tested the discover API endpoint with a path such as:
```
localhost:3000/discover/?url=https://some.sharepoint.com/_layouts/15/Doc.aspx?sourcedoc=%7B44CE4215-3123-434B-9648-D1EC8007B1B7%7D&file=this-is-the-file-name.docx&action=default&mobileredirect=true'
```
I only see everything up to `.../Doc.aspx` because it splits at the second `?`