### PR TITLE
fix: add 'import' condition for package imports

### DIFF
--- a/src/bundler/WebpackBundler.js
+++ b/src/bundler/WebpackBundler.js
@@ -80,7 +80,8 @@ export default class WebpackBundler extends BaseBundler {
           './main.js': cfg.file,
         },
         // use fixed conditions to omit the `development` condition.
-        conditionNames: ['node', 'require'],
+        // see: https://webpack.js.org/guides/package-exports/#conditions
+        conditionNames: ['node', 'require', 'import'],
       },
       node: {
         __dirname: true,


### PR DESCRIPTION
add `import` as condition for packages that exports conditionally, eg:

https://github.com/frenchbread/private-ip/blob/9d984ed3cd6d17d1d5a0f0d358c13c4c7a8996dd/package.json#L5-L10

