### PR TITLE
fix: remove condition names

### DIFF
--- a/src/bundler/WebpackBundler.js
+++ b/src/bundler/WebpackBundler.js
@@ -33,7 +33,7 @@ export default class WebpackBundler extends BaseBundler {
     const { cfg } = this;
     const opts = {
       target: 'node',
-      mode: 'development',
+      mode: 'production',
       // the universal adapter is the entry point
       entry: cfg.adapterFile || path.resolve(__dirname, '..', 'template', 'node-index.js'),
       context: cfg.cwd,
@@ -79,9 +79,15 @@ export default class WebpackBundler extends BaseBundler {
           // the main.js is imported in the universal adapter and is _the_ action entry point
           './main.js': cfg.file,
         },
-        // use fixed conditions to omit the `development` condition.
-        // see: https://webpack.js.org/guides/package-exports/#conditions
-        conditionNames: ['node', 'require', 'import', 'module'],
+      },
+      optimization: {
+        // we enable production mode in order to get the correct imports (eg micromark has special
+        // export condition for 'development'). but we disable minimize and keep named modules
+        // in order to easier match log errors to the bundle
+        minimize: false,
+        concatenateModules: false,
+        mangleExports: false,
+        moduleIds: 'named',
       },
       node: {
         __dirname: true,

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -193,7 +193,7 @@ describe('Edge Build Test', () => {
         '--arch', 'edge', // todo: allow to only generate the edge bundle
         '--verbose',
         '--directory', testRoot,
-        '--entryFile', 'index.js',
+        '--entryFile', 'src/index.js',
       ]);
 
     await builder.run();


### PR DESCRIPTION
- remove `condtionNames` from webpack bundler to make the module imports more stable
- switch to `production` mode so that packages that export different sources depending on the development/production mode use the production code (for example https://github.com/micromark/micromark/blob/8b08d16891f4d6801eb0c0e990bd7b87836c0826/packages/micromark-core-commonmark/package.json#L36-L39)
- disable minimize and keep named module ids for easier debugging