### PR TITLE
feat(aws): allow extra permissions to optionally include an alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ AWS Deployment Options
       --aws-log-format            The lambda log format. Can be either "JSON" or "Text". [string]
       --aws-layers                List of layers ARNs to attach to the lambda function.  [array]
       --aws-tracing-mode          The lambda tracing mode. Can be either "Active" or "PassThrough". [string]
-      --aws-extra-permissions     A list of additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>. [array]
+      --aws-extra-permissions     A list of additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>. Optionally, you can use <SourceARN>@<Principal>:<Alias> if you want to scope the permission to a specific alias. [array]
       --aws-tags                  A list of additional tags to attach to the lambda function in the form key=value. To remove a tag, use key= (i.e. without a value).[array]
 
 Google Deployment Options

--- a/src/deploy/AWSConfig.js
+++ b/src/deploy/AWSConfig.js
@@ -255,7 +255,7 @@ export default class AWSConfig {
         type: 'string',
       })
       .option('aws-extra-permissions', {
-        description: 'A list of additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>.',
+        description: 'A list of additional invoke permissions to add to the lambda function in the form <SourceARN>@<Principal>. Optionally, you can use <SourceARN>@<Principal>:<Alias> if you want to scope the permission to a specific alias.',
         type: 'string',
         array: true,
       })


### PR DESCRIPTION
## Description

When setting up Lambda functions that are triggered based on an SNS subscription, _if_ the subscription is tied to a specific function alias, the permission needs to be granted on the alias. This change allows for such permissions to be deployed through hedy.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

I have a function that receives SNS messages on a specific alias (prod) and NOT $LATEST.

## How Has This Been Tested?

I've used this commit to deploy and successfully sent SNS messages to the correct aliased version.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

> Note - I originally committed this as a 'fix' but on reconsideration, it's really a 'feat'.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
