### PR TITLE
fix(cloudflare): suffix should contain only the requested document pa…

### DIFF
--- a/src/template/adapter-utils.js
+++ b/src/template/adapter-utils.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env serviceworker */
+
+export function extractPathFromURL(request) {
+  const suffixMatches = /^https?:\/\/[^/]+([^?]+)/.exec(request.url);
+  return suffixMatches ? suffixMatches[1] : request.url.replace(/\?.*/, '');
+}

--- a/src/template/cloudflare-adapter.js
+++ b/src/template/cloudflare-adapter.js
@@ -11,6 +11,8 @@
  */
 /* eslint-env serviceworker */
 
+const { extractPathFromURL } = require('./adapter-utils.js');
+
 async function handler(event) {
   // console.log(event);
   const { request } = event;
@@ -19,7 +21,7 @@ async function handler(event) {
   const context = {
     resolver: null,
     pathInfo: {
-      suffix: request.url.replace(/\?.*/, ''),
+      suffix: extractPathFromURL(request.url),
     },
     runtime: {
       name: 'cloudflare-workers',

--- a/src/template/fastly-adapter.js
+++ b/src/template/fastly-adapter.js
@@ -12,6 +12,8 @@
 /* eslint-env serviceworker */
 /* global Dictionary */
 
+import { extractPathFromURL } from './adapter-utils.js';
+
 export function getEnvInfo(req, env) {
   const serviceVersion = env('FASTLY_SERVICE_VERSION');
   const requestId = env('FASTLY_TRACE_ID');
@@ -51,7 +53,7 @@ async function handler(event) {
     const context = {
       resolver: null,
       pathInfo: {
-        suffix: request.url.match(/^https?:\/\/[^/]+([^?]+)/)[1],
+        suffix: extractPathFromURL(request),
       },
       runtime: {
         name: 'compute-at-edge',

--- a/test/adapter-utils.test.js
+++ b/test/adapter-utils.test.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import assert from 'assert';
+import { extractPathFromURL } from '../src/template/adapter-utils.js';
+
+describe('Fastly Adapter Test', () => {
+  it('extract path from URL', () => {
+    const req = { url: 'https://www.adobe.com/path' };
+    const suffix = extractPathFromURL(req);
+    assert.equal(suffix, '/path');
+  });
+
+  it('URL is path', () => {
+    const req = { url: '/path?abc' };
+    const suffix = extractPathFromURL(req);
+    assert.equal(suffix, '/path');
+  });
+
+  it('URL is path', () => {
+    const req = { url: 'https://www.adobe.com/path/sub-path/sub-sub?query=parameter' };
+    const suffix = extractPathFromURL(req);
+    assert.equal(suffix, '/path/sub-path/sub-sub');
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For all templates the suffix only contains the path of the URL. For Cloudflare it is the complete URL which is not consistent

## Related Issue
N/A

## Motivation and Context

Having the same functions deployed everywhere and the context is consistent.

## How Has This Been Tested?

local deployment & testing

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
