### PR TITLE
fix: AWS Lambda not ready for updates fixes #727

### DIFF
--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -12,6 +12,7 @@
 /* eslint-disable no-await-in-loop,no-restricted-syntax */
 import chalk from 'chalk-template';
 import processQueue from '@adobe/helix-shared-process-queue';
+import { promisify } from 'util';
 
 import {
   DeleteObjectCommand,
@@ -56,6 +57,8 @@ import crypto from 'crypto';
 import BaseDeployer from './BaseDeployer.js';
 import ActionBuilder from '../ActionBuilder.js';
 import AWSConfig from './AWSConfig.js';
+
+const sleep = promisify(setTimeout);
 
 const API_GW_NAME_DEFAULT = 'API Managed by Helix Deploy';
 
@@ -991,7 +994,8 @@ export default class AWSDeployer extends BaseDeployer {
   }
 
   async checkFunctionReady(arn) {
-    let tries = 3;
+    let tries = 6;
+    let wait = 1500;
     while (tries > 0) {
       try {
         tries -= 1;
@@ -1006,9 +1010,8 @@ export default class AWSDeployer extends BaseDeployer {
           return;
         }
         // eslint-disable-next-line no-await-in-loop
-        await new Promise((resolve) => {
-          setTimeout(resolve, 1500);
-        });
+        await sleep(wait);
+        wait *= 2;
       } catch (e) {
         this.log.error(chalk`{red error}: error checking function state`);
         throw e;


### PR DESCRIPTION
AWS Lambda not ready for updates

## Description

Increase timeout via additional retries and backoff for checks for Lambda to be ready

## Related Issue

#727

## Motivation and Context

Deploys were failing due to the Lambda not being ready before the next step executed

## How Has This Been Tested?

 - Reproducing failing deploy locally
 - Making updates and linking this library
 - Re-attempting the same deploy

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
