### PR TITLE
fix: Removing awsLayers does not remove layers from a deployed function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-deploy",
-  "version": "12.0.9",
+  "version": "12.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-deploy",
-      "version": "12.0.9",
+      "version": "12.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -251,7 +251,7 @@ export default class AWSDeployer extends BaseDeployer {
         this._cfg.arch,
       ],
       LoggingConfig: this._cfg.logFormat ? { Format: this._cfg.logFormat } : undefined,
-      Layers: this._cfg.layers,
+      Layers: this._cfg.layers || [],
       TracingConfig: this._cfg.tracingMode ? { Mode: this._cfg.tracingMode } : undefined,
     };
 

--- a/test/aws.deployer.test.js
+++ b/test/aws.deployer.test.js
@@ -232,4 +232,35 @@ describe('AWS Deployer Test', () => {
 
     assert.strictEqual(aws.functionConfig.Handler, 'custom.handler');
   });
+
+  // https://github.com/adobe/helix-deploy/issues/734
+  it('uses empty array for Layers if no awsLayers is configured', async () => {
+    const cfg = new BaseConfig();
+    const awsCfg = new AWSConfig();
+    const builder = new ActionBuilder().withConfig(cfg);
+    await builder.validate();
+
+    const aws = new AWSDeployer(cfg, awsCfg);
+    assert.deepEqual(aws.functionConfig.Layers, []);
+  });
+
+  it('sets Layers if awsLayers is configured (1)', async () => {
+    const cfg = new BaseConfig();
+    const awsCfg = new AWSConfig().withAWSLayers(['my-layer:1']);
+    const builder = new ActionBuilder().withConfig(cfg);
+    await builder.validate();
+
+    const aws = new AWSDeployer(cfg, awsCfg);
+    assert.deepEqual(aws.functionConfig.Layers, ['my-layer:1']);
+  });
+
+  it('sets Layers if awsLayers is configured (2)', async () => {
+    const cfg = new BaseConfig();
+    const awsCfg = new AWSConfig().withAWSLayers(['my-layer:1', 'my-other-layer:1']);
+    const builder = new ActionBuilder().withConfig(cfg);
+    await builder.validate();
+
+    const aws = new AWSDeployer(cfg, awsCfg);
+    assert.deepEqual(aws.functionConfig.Layers, ['my-layer:1', 'my-other-layer:1']);
+  });
 });


### PR DESCRIPTION
## Description

Fixes #734. Always set `Layers` to an array, even if `awsLayers` is not configured.

## How Has This Been Tested?

Manually verified that setting an empty `Layers` array on Lambda will overwrite and remove any previously set layers.

Added 3 new unit tests for cases
- no `awsLayers` set
- `awsLayers` with 1 layer
- `awsLayers` with 2 layers

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
