### PR TITLE
feat(aws): lookup role given as name instead of ARN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@adobe/helix-deploy",
-  "version": "14.0.11",
+  "version": "14.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-deploy",
-      "version": "14.0.11",
+      "version": "14.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
         "@adobe/helix-shared-process-queue": "3.1.9",
         "@aws-sdk/client-apigatewayv2": "3.1076.0",
+        "@aws-sdk/client-iam": "3.1086.0",
         "@aws-sdk/client-lambda": "3.1076.0",
         "@aws-sdk/client-s3": "3.1076.0",
         "@aws-sdk/client-secrets-manager": "3.1076.0",
@@ -423,6 +424,25 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-iam": {
+      "version": "3.1086.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.1086.0.tgz",
+      "integrity": "sha512-cXQA5+llrHT5YEJ0azehl8gfCMI3Dr8y6avGCC4BqTE7RsBDhXx2mNrRrCiqAnXts9+t4wAqkihUmT9sAkn72g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.67",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.1076.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1076.0.tgz",
@@ -534,17 +554,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.24.tgz",
-      "integrity": "sha512-vWB/qJl21vxGKBkBN8fKPTVXgm14v/bUQWTtR5oikrfAZbIN2bxuSiCY5rRAMR4gs3vtR2Vw0aTfVDU4tdfIPg==",
+      "version": "3.975.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.14",
-        "@aws-sdk/xml-builder": "^3.972.32",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.27.0",
-        "@smithy/signature-v4": "^5.5.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -553,15 +573,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.50.tgz",
-      "integrity": "sha512-l8bWzhPFTi9tDcvtURxeMlfsboul5/0sEN3SwwXxdpYudVB9+EuQcxo2pwlTzXwDo4Gm2VLGyiZ8zti3nfdOLw==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -569,17 +589,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.52.tgz",
-      "integrity": "sha512-FjAlnsIvemWzO3JTM3ObuuxpqCyrqkXOewlYY2+NiR1MYO1JuFYSIJ8SJN5Q2KD1jkL5lIuab8awjb/AxsvjiQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -587,23 +607,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.57.tgz",
-      "integrity": "sha512-8qwNhQ0sK/1KaOpVEFC7TFxrWP3fxzJV1K049MzjouiMIbvTDvIGDEUtj5ND5aTmlHVK/YZxjoYnLCeV/GZU0w==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/credential-provider-env": "^3.972.50",
-        "@aws-sdk/credential-provider-http": "^3.972.52",
-        "@aws-sdk/credential-provider-login": "^3.972.56",
-        "@aws-sdk/credential-provider-process": "^3.972.50",
-        "@aws-sdk/credential-provider-sso": "^3.972.56",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.56",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/credential-provider-imds": "^4.4.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -611,16 +631,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.56.tgz",
-      "integrity": "sha512-S36dCrDaafakFMlaCVGAF4advbQKoJuMcyMtNWVBpUz65uqhbIAsUfvAyp+djA+jkzaEfgZGd+AELjIGzTqyhw==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -628,21 +648,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.59.tgz",
-      "integrity": "sha512-LkczBXaEsdManijlEZwbKfEoo1C98Yri3LHF8gQI7CYWv+uFkmpS3OZH3BSew8g1A2ppKsScdPUSlhI6NV7a9g==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.67.tgz",
+      "integrity": "sha512-oYlzWst56rlhhjbYnexwv5hVLYe1cW4liLObhDfxDLI4RAQzleMVHQgQgx7XsC4HKj4e3kjT8v9DId+Pi/dndw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.50",
-        "@aws-sdk/credential-provider-http": "^3.972.52",
-        "@aws-sdk/credential-provider-ini": "^3.972.57",
-        "@aws-sdk/credential-provider-process": "^3.972.50",
-        "@aws-sdk/credential-provider-sso": "^3.972.56",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.56",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/credential-provider-imds": "^4.4.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -650,15 +670,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.50.tgz",
-      "integrity": "sha512-ARBEVkOQzmowTU0a35smGVyldJ9FN/f57XIGrPatrul4mYN+vvOKxoc1njDOX3nugVze+0sHzQZWJ8kPARAtUA==",
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -666,17 +686,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.56.tgz",
-      "integrity": "sha512-LvbWiFcLI/D5RPaT68TrpLLHyv7x5X+dm59wJ5dFizyGPZggBC7OdgJTlP0X1bVjiSSAgE1u1oxxcBps0GCEnA==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/token-providers": "3.1076.0",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -684,16 +704,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.56.tgz",
-      "integrity": "sha512-OV3JxmqMphVGMLWupYD2UhZxX07ATk1NwyYk7RgCnAEh0y3owHmtEnkWZ3ciCZ6liiFEwS8dYQpJGmKsR6ml4Q==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -731,20 +751,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.24.tgz",
-      "integrity": "sha512-+wFVfVofxeiXdRhUjRwYISB2mVfBCdiCq1wThkRipTeOc10Kyr+LS9QJTjgZuhWsna7jyLMPndrCnzLGWWvZXg==",
+      "version": "3.997.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.36",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/fetch-http-handler": "^5.6.0",
-        "@smithy/node-http-handler": "^4.9.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -752,14 +770,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.36.tgz",
-      "integrity": "sha512-VSOWIPkI+g3a7NkxIBCO24HnsR0BZXJAi3wrKaGIZwVKyrMtNRdHxPrQI/igazgla5J9FhDzmg4RgnOSr6UQBw==",
+      "version": "3.996.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/signature-v4": "^5.5.3",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -767,16 +785,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1076.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1076.0.tgz",
-      "integrity": "sha512-4rTHETRKe2JWAsFUMo5ENmlzc3i9FD4KqBVXgoaF8DLTADjGid8SA+1LR2nJWjefoafvKAHcQH9F2iKa8uHc6Q==",
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.24",
-        "@aws-sdk/nested-clients": "^3.997.24",
-        "@aws-sdk/types": "^3.973.14",
-        "@smithy/core": "^3.27.0",
-        "@smithy/types": "^4.15.0",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -784,12 +802,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.14.tgz",
-      "integrity": "sha512-vH4pEu9YBEwr67yT+GVcmKX0GzfIrIYUn+MF5vXg9OspouVnAekuyVyawFvZHEK7WlcwVDwNrqI3ZBDUAiyu9A==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -809,12 +827,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.32.tgz",
-      "integrity": "sha512-2loKuOMRFDg1nwdni5AtJ9S5juVbRNPNsPC7tWTfkHyycPwACMhxepspUHi8GhvfNlL2cQo3sPMod1uib+KZ0w==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.16.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -822,9 +840,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -2456,12 +2474,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.28.0.tgz",
-      "integrity": "sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
+      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2469,13 +2487,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.4.tgz",
-      "integrity": "sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
+      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2483,13 +2501,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.1.tgz",
-      "integrity": "sha512-fW6l9rWoyk1iyzfuZaERnZLNjB6WIojgGm6Bo9Hpfpy3RUpltjLikNlxTsS/YtxVobcfbCGBuAncREYqT4hvqQ==",
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
+      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2497,13 +2515,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.1.tgz",
-      "integrity": "sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
+      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2511,13 +2529,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.0.tgz",
-      "integrity": "sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
+      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.28.0",
-        "@smithy/types": "^4.15.0",
+        "@smithy/core": "^3.29.3",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2525,9 +2543,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
-      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@adobe/fetch": "4.3.0",
     "@adobe/helix-shared-process-queue": "3.1.9",
     "@aws-sdk/client-apigatewayv2": "3.1076.0",
+    "@aws-sdk/client-iam": "3.1086.0",
     "@aws-sdk/client-lambda": "3.1076.0",
     "@aws-sdk/client-s3": "3.1076.0",
     "@aws-sdk/client-secrets-manager": "3.1076.0",

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -48,6 +48,8 @@ import {
   GetStagesCommand, UpdateAuthorizerCommand, UpdateRouteCommand,
 } from '@aws-sdk/client-apigatewayv2';
 
+import { GetRoleCommand, IAMClient } from '@aws-sdk/client-iam';
+
 import { PutParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 
 import { PutSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
@@ -180,18 +182,32 @@ export default class AWSDeployer extends BaseDeployer {
   }
 
   async initAccountId() {
-    let sts;
+    const sts = new STSClient({
+      region: this._cfg.region,
+    });
 
     try {
-      sts = new STSClient({
-        region: this._cfg.region,
-      });
       const ret = await sts.send(new GetCallerIdentityCommand());
       this._accountId = ret.Account;
       this.log.info(chalk`{green ok:} initialized AWS deployer for account {yellow ${ret.Account}}`);
       this._bucket = this._cfg.deployBucket || `helix-deploy-bucket-${this._accountId}${this._cfg.region !== 'us-east-1' ? `-${this._cfg.region}` : ''}`;
     } finally {
       sts.destroy();
+    }
+  }
+
+  async lookupRole(roleName) {
+    const iam = new IAMClient({
+      region: this._cfg.region,
+    });
+
+    try {
+      const ret = await iam.send(new GetRoleCommand({
+        RoleName: roleName,
+      }));
+      return ret.Role.Arn;
+    } finally {
+      iam.destroy();
     }
   }
 
@@ -225,8 +241,13 @@ export default class AWSDeployer extends BaseDeployer {
     this.log.info(chalk`{green ok:} deleted deploy package {blueBright s3://${this._bucket}/${this._key}}.`);
   }
 
-  get functionConfig() {
+  async getFunctionConfig() {
     const { cfg, functionName, additionalTags } = this;
+
+    let roleName = this._cfg.role;
+    if (!!roleName && roleName.indexOf(':') === -1) {
+      roleName = await this.lookupRole(roleName);
+    }
 
     const functionConfig = {
       Code: {
@@ -235,7 +256,7 @@ export default class AWSDeployer extends BaseDeployer {
       },
       // todo: package name
       FunctionName: functionName,
-      Role: this._cfg.role,
+      Role: roleName,
       Runtime: `nodejs${cfg.nodeVersion}.x`,
       // todo: cram annotations into description?
       Tags: {
@@ -282,9 +303,8 @@ export default class AWSDeployer extends BaseDeployer {
   }
 
   async createLambda() {
-    const {
-      cfg, functionName, additionalTags, functionConfig,
-    } = this;
+    const { cfg, functionName, additionalTags } = this;
+    const functionConfig = await this.getFunctionConfig();
     const functionVersion = cfg.version.replace(/\./g, '_');
 
     this.log.info(`--: using lambda role "${this._cfg.role}"`);

--- a/test/aws.deployer.test.js
+++ b/test/aws.deployer.test.js
@@ -39,6 +39,17 @@ const awsNock = {
         },
       },
     })),
+  lookupRole: (roleName) => nock('https://iam.amazonaws.com')
+    .post('/', (body) => body.Action === 'GetRole')
+    .reply(200, new xml2js.Builder().buildObject({
+      GetRoleResponse: {
+        GetRoleResult: {
+          Role: {
+            Arn: `arn:aws:iam::123456789012:role/${roleName}`,
+          },
+        },
+      },
+    })),
 };
 
 describe('AWS Deployer Test', () => {
@@ -71,28 +82,38 @@ describe('AWS Deployer Test', () => {
       }
     });
   });
+
   it('sets the default lambda name', async () => {
+    awsNock.lookupRole('somerole');
+
     const cfg = new BaseConfig()
       .withName('/helix-services/static@4.3.1');
-    const awsCfg = new AWSConfig();
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
+      .withAWSRole('somerole');
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
     const aws = new AWSDeployer(cfg, awsCfg);
 
     assert.strictEqual(aws.functionName, 'helix-services--static');
-    assert.strictEqual(aws.functionConfig.FunctionName, 'helix-services--static');
+
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(functionConfig.FunctionName, 'helix-services--static');
   });
 
   it('sets the default lambda with dots', async () => {
     const cfg = new BaseConfig()
       .withName('/helix-services/gorky.v8@4.3.1');
-    const awsCfg = new AWSConfig();
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1');
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
     const aws = new AWSDeployer(cfg, awsCfg);
 
     assert.strictEqual(aws.functionName, 'helix-services--gorky_v8');
-    assert.strictEqual(aws.functionConfig.FunctionName, 'helix-services--gorky_v8');
+
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(functionConfig.FunctionName, 'helix-services--gorky_v8');
   });
 
   it('sets the default function path', async () => {
@@ -100,7 +121,8 @@ describe('AWS Deployer Test', () => {
       .withVersion('1.18.2')
       // eslint-disable-next-line no-template-curly-in-string
       .withName('/helix-services/static@${version}');
-    const awsCfg = new AWSConfig();
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1');
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
     const aws = new AWSDeployer(cfg, awsCfg);
@@ -165,6 +187,7 @@ describe('AWS Deployer Test', () => {
         aws: '/pages_${version}/${scriptName}',
       });
     const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
       // eslint-disable-next-line no-template-curly-in-string
       .withAWSLambdaFormat('pages--${scriptName}');
     const builder = new ActionBuilder().withConfig(cfg);
@@ -173,7 +196,9 @@ describe('AWS Deployer Test', () => {
 
     assert.strictEqual(aws.functionName, 'pages--html');
     assert.strictEqual(aws.functionPath, '/pages_4.3.1/html');
-    assert.strictEqual(aws.functionConfig.FunctionName, 'pages--html');
+
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(functionConfig.FunctionName, 'pages--html');
   });
 
   it('cleans up old versions', async () => {
@@ -273,13 +298,14 @@ describe('AWS Deployer Test', () => {
       .withVersion('1.18.2')
       // eslint-disable-next-line no-template-curly-in-string
       .withName('/helix-services/static@${version}');
-    const awsCfg = new AWSConfig();
+    const awsCfg = new AWSConfig().withAWSRegion('us-east-1');
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
     const aws = new AWSDeployer(cfg, awsCfg);
 
     assert.deepStrictEqual(aws.additionalTags, {});
-    assert.strictEqual(Object.keys(aws.functionConfig.Tags).length, 4);
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(Object.keys(functionConfig.Tags).length, 4);
   });
 
   it('correctly transforms tags into an object', async () => {
@@ -287,7 +313,9 @@ describe('AWS Deployer Test', () => {
       .withVersion('1.18.2')
       // eslint-disable-next-line no-template-curly-in-string
       .withName('/helix-services/static@${version}');
-    const awsCfg = new AWSConfig().withAWSTags(['foo=bar', 'baz=qux=quux']);
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
+      .withAWSTags(['foo=bar', 'baz=qux=quux']);
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
     const aws = new AWSDeployer(cfg, awsCfg);
@@ -296,8 +324,10 @@ describe('AWS Deployer Test', () => {
       foo: 'bar',
       baz: 'qux=quux',
     });
-    assert.strictEqual(aws.functionConfig.Tags.foo, 'bar');
-    assert.strictEqual(aws.functionConfig.Tags.baz, 'qux=quux');
+
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(functionConfig.Tags.foo, 'bar');
+    assert.strictEqual(functionConfig.Tags.baz, 'qux=quux');
   });
 
   it('creates an error if awsTags is set as an object', async () => {
@@ -312,22 +342,26 @@ describe('AWS Deployer Test', () => {
       .withVersion('1.18.2')
       // eslint-disable-next-line no-template-curly-in-string
       .withName('/helix-services/static@${version}');
-    const awsCfg = new AWSConfig().withAWSEphemeralStorage(2048);
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
+      .withAWSEphemeralStorage(2048);
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.deepStrictEqual(aws.functionConfig.EphemeralStorage, { Size: 2048 });
+    const functionConfig = await aws.getFunctionConfig();
+    assert.deepStrictEqual(functionConfig.EphemeralStorage, { Size: 2048 });
   });
 
   it('does not set EphemeralStorage if not configured', async () => {
     const cfg = new BaseConfig();
-    const awsCfg = new AWSConfig();
+    const awsCfg = new AWSConfig().withAWSRegion('us-east-1');
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.strictEqual(aws.functionConfig.EphemeralStorage, undefined);
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(functionConfig.EphemeralStorage, undefined);
   });
 
   it('creates an error if aws-ephemeral-storage is below 512', async () => {
@@ -356,39 +390,46 @@ describe('AWS Deployer Test', () => {
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-
-    assert.strictEqual(aws.functionConfig.Handler, 'custom.handler');
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(functionConfig.Handler, 'custom.handler');
   });
 
   // https://github.com/adobe/helix-deploy/issues/734
   it('uses empty array for Layers if no awsLayers is configured', async () => {
     const cfg = new BaseConfig();
-    const awsCfg = new AWSConfig();
+    const awsCfg = new AWSConfig().withAWSRegion('us-east-1');
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.deepEqual(aws.functionConfig.Layers, []);
+    const functionConfig = await aws.getFunctionConfig();
+    assert.deepEqual(functionConfig.Layers, []);
   });
 
   it('sets Layers if awsLayers is configured (1)', async () => {
     const cfg = new BaseConfig();
-    const awsCfg = new AWSConfig().withAWSLayers(['my-layer:1']);
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
+      .withAWSLayers(['my-layer:1']);
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.deepEqual(aws.functionConfig.Layers, ['my-layer:1']);
+    const functionConfig = await aws.getFunctionConfig();
+    assert.deepEqual(functionConfig.Layers, ['my-layer:1']);
   });
 
   it('sets Layers if awsLayers is configured (2)', async () => {
     const cfg = new BaseConfig();
-    const awsCfg = new AWSConfig().withAWSLayers(['my-layer:1', 'my-other-layer:1']);
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
+      .withAWSLayers(['my-layer:1', 'my-other-layer:1']);
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.deepEqual(aws.functionConfig.Layers, ['my-layer:1', 'my-other-layer:1']);
+    const functionConfig = await aws.getFunctionConfig();
+    assert.deepEqual(functionConfig.Layers, ['my-layer:1', 'my-other-layer:1']);
   });
 
   async function createBaseConfig({
@@ -564,24 +605,27 @@ describe('AWS Deployer Test', () => {
 
   it('does not set VpcConfig if VPC flags are not configured', async () => {
     const cfg = new BaseConfig();
-    const awsCfg = new AWSConfig();
+    const awsCfg = new AWSConfig().withAWSRegion('us-east-1');
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.strictEqual(aws.functionConfig.VpcConfig, undefined);
+    const functionConfig = await aws.getFunctionConfig();
+    assert.strictEqual(functionConfig.VpcConfig, undefined);
   });
 
   it('sets VpcConfig when both VPC flags are configured', async () => {
     const cfg = new BaseConfig();
     const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
       .withAWSVpcSubnetIds(['subnet-abc123', 'subnet-def456'])
       .withAWSVpcSecurityGroupIds(['sg-abc123']);
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.deepStrictEqual(aws.functionConfig.VpcConfig, {
+    const functionConfig = await aws.getFunctionConfig();
+    assert.deepStrictEqual(functionConfig.VpcConfig, {
       SubnetIds: ['subnet-abc123', 'subnet-def456'],
       SecurityGroupIds: ['sg-abc123'],
     });
@@ -590,13 +634,15 @@ describe('AWS Deployer Test', () => {
   it('sets VpcConfig with empty arrays for VPC detach', async () => {
     const cfg = new BaseConfig();
     const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
       .withAWSVpcSubnetIds([])
       .withAWSVpcSecurityGroupIds([]);
     const builder = new ActionBuilder().withConfig(cfg);
     await builder.validate();
 
     const aws = new AWSDeployer(cfg, awsCfg);
-    assert.deepStrictEqual(aws.functionConfig.VpcConfig, {
+    const functionConfig = await aws.getFunctionConfig();
+    assert.deepStrictEqual(functionConfig.VpcConfig, {
       SubnetIds: [],
       SecurityGroupIds: [],
     });

--- a/test/aws.deployer.test.js
+++ b/test/aws.deployer.test.js
@@ -99,6 +99,7 @@ describe('AWS Deployer Test', () => {
 
     const functionConfig = await aws.getFunctionConfig();
     assert.strictEqual(functionConfig.FunctionName, 'helix-services--static');
+    assert.strictEqual(functionConfig.Role, 'arn:aws:iam::123456789012:role/somerole');
   });
 
   it('sets the default lambda with dots', async () => {


### PR DESCRIPTION
Using an absolute ARN in the `package.json` limits the deployment because the account ID is hardcoded. Instead, use a name, only, and look it up in IAM.