### PR TITLE
feat: deploy proxy in new API Gateway

### DIFF
--- a/src/BaseConfig.js
+++ b/src/BaseConfig.js
@@ -631,6 +631,7 @@ export default class BaseConfig {
         description: 'Create symlinks (sequences) after deployment. "major" and "minor" will create respective version links',
         type: 'string',
         array: true,
+        default: [],
       })
       .option('delete', {
         description: 'Delete the action from OpenWhisk. Implies no-build',

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -58,6 +58,7 @@ import crypto from 'crypto';
 import BaseDeployer from './BaseDeployer.js';
 import ActionBuilder from '../ActionBuilder.js';
 import AWSConfig from './AWSConfig.js';
+import AWSProxyDeployer from './AWSProxyDeployer.js';
 
 const sleep = promisify(setTimeout);
 
@@ -138,6 +139,10 @@ export default class AWSDeployer extends BaseDeployer {
       }
       return acc;
     }, {});
+  }
+
+  get accountId() {
+    return this._accountId;
   }
 
   validate() {
@@ -552,6 +557,10 @@ export default class AWSDeployer extends BaseDeployer {
         ApiId,
       }));
     }
+
+    // a freshly created API has no routes yet: deploy the shared helix-deploy-proxy
+    // Lambda and its routes
+    await new AWSProxyDeployer(this).deploy(ApiId);
 
     if (this._cfg.createRoutes) {
       // find integration

--- a/src/deploy/AWSProxyDeployer.js
+++ b/src/deploy/AWSProxyDeployer.js
@@ -28,6 +28,7 @@ import { CreateIntegrationCommand } from '@aws-sdk/client-apigatewayv2';
 const __dirname = path.resolve(fileURLToPath(import.meta.url), '..');
 
 const FUNCTION_NAME = 'helix-deploy-proxy';
+const ROLE_NAME = 'helix-role-deploy-proxy';
 
 // packages served by the proxy, see the routes documented in src/template/aws-proxy-code.js
 const ROUTE_PACKAGES = ['helix-services', 'helix3'];
@@ -104,7 +105,7 @@ export default class AWSProxyDeployer {
         FunctionName: FUNCTION_NAME,
         Runtime: `nodejs${deployer.cfg.nodeVersion}.x`,
         Handler: 'index.handler',
-        Role: `arn:aws:iam::${deployer.accountId}:role/helix-role-deploy-proxy`,
+        Role: `arn:aws:iam::${deployer.accountId}:role/${ROLE_NAME}`,
         Description: 'Helix Deploy Proxy',
         Timeout: 60,
         Code: { ZipFile: zipFile },

--- a/src/deploy/AWSProxyDeployer.js
+++ b/src/deploy/AWSProxyDeployer.js
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import path from 'path';
+import { fileURLToPath } from 'url';
+import crypto from 'crypto';
+import archiver from 'archiver';
+import chalk from 'chalk-template';
+
+import {
+  AddPermissionCommand,
+  CreateFunctionCommand,
+  GetFunctionCommand,
+  UpdateFunctionCodeCommand,
+} from '@aws-sdk/client-lambda';
+
+import { CreateIntegrationCommand } from '@aws-sdk/client-apigatewayv2';
+
+// eslint-disable-next-line no-underscore-dangle
+const __dirname = path.resolve(fileURLToPath(import.meta.url), '..');
+
+const FUNCTION_NAME = 'helix-deploy-proxy';
+
+// packages served by the proxy, see the routes documented in src/template/aws-proxy-code.js
+const ROUTE_PACKAGES = ['helix-services', 'helix3'];
+
+/**
+ * Deploys the shared `helix-deploy-proxy` Lambda function (src/template/aws-proxy-code.js)
+ * and installs the routes it serves:
+ *
+ * ANY /helix-services/{action}/{version}
+ * ANY /helix-services/{action}/{version}/{path+}
+ * ANY /helix3/{action}/{version}
+ * ANY /helix3/{action}/{version}/{path+}
+ *
+ * This is used to bootstrap a freshly created API, reusing the clients and route/integration
+ * helpers of the owning AWSDeployer.
+ */
+export default class AWSProxyDeployer {
+  /**
+   * @param {AWSDeployer} awsDeployer the deployer that owns the AWS clients and config
+   */
+  constructor(awsDeployer) {
+    this._deployer = awsDeployer;
+  }
+
+  get log() {
+    return this._deployer.log;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async buildZip() {
+    return new Promise((resolve, reject) => {
+      const archive = archiver('zip');
+      const chunks = [];
+      archive.on('data', (chunk) => {
+        chunks.push(chunk);
+      });
+      archive.on('error', (err) => {
+        reject(err);
+      });
+      archive.on('end', () => {
+        resolve(Buffer.concat(chunks));
+      });
+      archive.file(path.resolve(__dirname, '..', 'template', 'aws-proxy-code.js'), { name: 'index.mjs' });
+      archive.finalize();
+    });
+  }
+
+  async deployFunction() {
+    const { _deployer: deployer, log } = this;
+    const zipFile = await this.buildZip();
+
+    let FunctionArn;
+    try {
+      log.info(chalk`--: checking existing proxy Lambda function {yellow ${FUNCTION_NAME}}`);
+      // eslint-disable-next-line no-underscore-dangle
+      const { Configuration } = await deployer._lambda.send(new GetFunctionCommand({
+        FunctionName: FUNCTION_NAME,
+      }));
+      FunctionArn = Configuration.FunctionArn;
+      await deployer.checkFunctionReady(FunctionArn);
+      log.info(chalk`--: updating proxy Lambda function code {yellow ${FUNCTION_NAME}}`);
+      // eslint-disable-next-line no-underscore-dangle
+      await deployer._lambda.send(new UpdateFunctionCodeCommand({
+        FunctionName: FUNCTION_NAME,
+        ZipFile: zipFile,
+      }));
+    } catch (e) {
+      if (e.name !== 'ResourceNotFoundException') {
+        throw e;
+      }
+      log.info(chalk`--: creating proxy Lambda function {yellow ${FUNCTION_NAME}}`);
+      // eslint-disable-next-line no-underscore-dangle
+      const res = await deployer._lambda.send(new CreateFunctionCommand({
+        FunctionName: FUNCTION_NAME,
+        Runtime: `nodejs${deployer.cfg.nodeVersion}.x`,
+        Handler: 'index.handler',
+        Role: `arn:aws:iam::${deployer.accountId}:role/helix-role-deploy-proxy`,
+        Description: 'Helix Deploy Proxy',
+        Timeout: 60,
+        Code: { ZipFile: zipFile },
+      }));
+      FunctionArn = res.FunctionArn;
+    }
+    await deployer.checkFunctionReady(FunctionArn);
+    log.info(chalk`{green ok:} proxy function ready {yellow ${FunctionArn}}`);
+    return FunctionArn;
+  }
+
+  async createRoutesAndPermissions(ApiId, FunctionArn) {
+    const { _deployer: deployer, log } = this;
+
+    let integration = await deployer.findIntegration(ApiId, FunctionArn);
+    if (integration) {
+      log.info(`--: using existing integration "${integration.IntegrationId}" for "${FunctionArn}"`);
+    } else {
+      // eslint-disable-next-line no-underscore-dangle
+      integration = await deployer._api.send(new CreateIntegrationCommand({
+        ApiId,
+        IntegrationMethod: 'POST',
+        IntegrationType: 'AWS_PROXY',
+        IntegrationUri: FunctionArn,
+        PayloadFormatVersion: '2.0',
+        TimeoutInMillis: 30000,
+      }));
+      log.info(chalk`{green ok:} created new integration "${integration.IntegrationId}" for "${FunctionArn}"`);
+    }
+
+    const { IntegrationId } = integration;
+    const routes = await deployer.fetchRoutes(ApiId);
+    const routeParams = {
+      ApiId,
+      Target: `integrations/${IntegrationId}`,
+    };
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const pkg of ROUTE_PACKAGES) {
+      // eslint-disable-next-line no-await-in-loop
+      await deployer.createOrUpdateRoute(routes, routeParams, `ANY /${pkg}/{action}/{version}`);
+      // eslint-disable-next-line no-await-in-loop
+      await deployer.createOrUpdateRoute(routes, routeParams, `ANY /${pkg}/{action}/{version}/{path+}`);
+
+      // eslint-disable-next-line no-underscore-dangle
+      const sourceArn = `arn:aws:execute-api:${deployer._cfg.region}:${deployer._accountId}:${ApiId}/*/*/${pkg}/*`;
+      try {
+        // eslint-disable-next-line no-await-in-loop,no-underscore-dangle
+        await deployer._lambda.send(new AddPermissionCommand({
+          FunctionName: FunctionArn,
+          Action: 'lambda:InvokeFunction',
+          SourceArn: sourceArn,
+          Principal: 'apigateway.amazonaws.com',
+          StatementId: crypto.createHash('md5').update(FunctionArn + sourceArn).digest('hex'),
+        }));
+        log.info(chalk`{green ok:} added invoke permissions for ${sourceArn}`);
+      } catch (e) {
+        // ignore, most likely the permission already exists
+      }
+    }
+  }
+
+  async deploy(ApiId) {
+    const FunctionArn = await this.deployFunction();
+    await this.createRoutesAndPermissions(ApiId, FunctionArn);
+  }
+}

--- a/src/template/aws-proxy-code.js
+++ b/src/template/aws-proxy-code.js
@@ -21,8 +21,8 @@ import { LambdaClient, InvokeCommand, InvocationType } from '@aws-sdk/client-lam
  * ANY /helix-services/{action}/{version}
  * ANY /helix-services/{action}/{version}/{path+}
  *
- * ANY /helix-observation/{action}/{version}
- * ANY /helix-observation/{action}/{version}/{path+}
+ * ANY /helix3/{action}/{version}
+ * ANY /helix3/{action}/{version}/{path+}
  *
  * Note that the package cannot be a path parameter, as it would clash with the pages proxy
  *

--- a/test/aws.deployer.test.js
+++ b/test/aws.deployer.test.js
@@ -472,6 +472,9 @@ describe('AWS Deployer Test', () => {
       .withAWSApi('create');
     const aws = new AWSDeployer(cfg, awsCfg);
     const apiBase = 'https://apigateway.us-east-1.amazonaws.com';
+    const lambdaBase = 'https://lambda.us-east-1.amazonaws.com';
+    const proxyFunctionArn = 'arn:aws:lambda:us-east-1:123456789012:function:helix-deploy-proxy';
+
     const createApiRequest = nock(apiBase)
       .post('/v2/apis', () => true)
       .reply(200, {
@@ -485,6 +488,40 @@ describe('AWS Deployer Test', () => {
       .post('/v2/apis/newapi/stages', (body) => body.stageName === '$default' && body.autoDeploy === true)
       .reply(201, {});
 
+    const getProxyFunctionRequest = nock(lambdaBase)
+      .get('/2015-03-31/functions/helix-deploy-proxy')
+      .reply(404, { message: 'Function not found' }, { 'x-amzn-errortype': 'ResourceNotFoundException' });
+    const createProxyFunctionRequest = nock(lambdaBase)
+      .post('/2015-03-31/functions', (body) => body.FunctionName === 'helix-deploy-proxy')
+      .reply(201, { FunctionArn: proxyFunctionArn });
+    const checkProxyFunctionReadyRequest = nock(lambdaBase)
+      .get(`/2015-03-31/functions/${encodeURIComponent(proxyFunctionArn)}`)
+      .reply(200, {
+        Configuration: {
+          FunctionArn: proxyFunctionArn,
+          State: 'Active',
+          LastUpdateStatus: 'Successful',
+        },
+      });
+
+    const getIntegrationsRequest = nock(apiBase)
+      .get('/v2/apis/newapi/integrations')
+      .reply(200, { items: [] });
+    const createIntegrationRequest = nock(apiBase)
+      .post('/v2/apis/newapi/integrations', (body) => body.integrationUri === proxyFunctionArn)
+      .reply(201, { integrationId: 'proxy-integration-id' });
+    const getRoutesRequest = nock(apiBase)
+      .get('/v2/apis/newapi/routes')
+      .reply(200, { items: [] });
+    const createRouteRequests = nock(apiBase)
+      .post('/v2/apis/newapi/routes', () => true)
+      .times(4)
+      .reply(201, {});
+    const addPermissionRequests = nock(lambdaBase)
+      .post(`/2015-03-31/functions/${encodeURIComponent(proxyFunctionArn)}/policy`, () => true)
+      .times(2)
+      .reply(201, {});
+
     await aws.init();
     await aws.initAccountId();
     await aws.createAPI();
@@ -492,6 +529,14 @@ describe('AWS Deployer Test', () => {
     assert.ok(createApiRequest.isDone());
     assert.ok(getStagesRequest.isDone());
     assert.ok(createStageRequest.isDone());
+    assert.ok(getProxyFunctionRequest.isDone());
+    assert.ok(createProxyFunctionRequest.isDone());
+    assert.ok(checkProxyFunctionReadyRequest.isDone());
+    assert.ok(getIntegrationsRequest.isDone());
+    assert.ok(createIntegrationRequest.isDone());
+    assert.ok(getRoutesRequest.isDone());
+    assert.ok(createRouteRequests.isDone());
+    assert.ok(addPermissionRequests.isDone());
     assert.strictEqual(aws.fullFunctionName, `https://example.execute-api.us-east-1.amazonaws.com${aws.functionPath}`);
   });
 


### PR DESCRIPTION
## Summary
- Adds `AWSProxyDeployer`, which bootstraps the shared `helix-deploy-proxy` Lambda function and its `/helix-services` and `/helix3` routes on a freshly created API Gateway (which otherwise has no routes yet)
- Renames the previously documented `helix-observation` route prefix to `helix3` in `aws-proxy-code.js`
- Defaults the `links` config option to an empty array in `BaseConfig.js`

## Test plan
- [x] `npx mocha test/aws.deployer.test.js` — 44 passing
- [x] `npx eslint` on changed files — clean