### PR TITLE
feat(aws): support testing lambda directly when `--aws-api=none`

### DIFF
--- a/src/BaseConfig.js
+++ b/src/BaseConfig.js
@@ -292,7 +292,7 @@ export default class BaseConfig {
   }
 
   get testPath() {
-    if (!this.test.startsWith('/') && this.testUrl) {
+    if (!this.test?.startsWith('/') && this.testUrl) {
       return this.testUrl;
     }
     return this.test;

--- a/src/deploy/AWSDeployer.js
+++ b/src/deploy/AWSDeployer.js
@@ -29,7 +29,7 @@ import {
   AddPermissionCommand,
   CreateAliasCommand,
   CreateFunctionCommand, DeleteAliasCommand, DeleteFunctionCommand, GetAliasCommand,
-  GetFunctionCommand,
+  GetFunctionCommand, InvokeCommand,
   LambdaClient, ListAliasesCommand, ListTagsCommand, ListVersionsByFunctionCommand,
   PublishVersionCommand, PutFunctionConcurrencyCommand, TagResourceCommand,
   UntagResourceCommand, UpdateAliasCommand,
@@ -645,11 +645,11 @@ export default class AWSDeployer extends BaseDeployer {
   }
 
   async test() {
+    if (this._cfg.apiId === 'none') {
+      return this.testInvoke({ retry404: 5 });
+    }
     let url = this._functionURL;
     if (!url) {
-      if (this._cfg.apiId === 'none') {
-        throw new Error('Unable to test function: no API Gateway configured (--aws-api=none).');
-      }
       url = `https://${this._cfg.apiId}.execute-api.${this._cfg.region}.amazonaws.com${this.functionPath}`;
     }
     return this.testRequest({
@@ -657,6 +657,75 @@ export default class AWSDeployer extends BaseDeployer {
       idHeader: 'apigw-requestid',
       retry404: 5,
     });
+  }
+
+  /**
+   * Tests the deployed function by invoking it directly via the Lambda `Invoke` API. Used
+   * when no API Gateway is configured (`--aws-api=none`) and the function can't be reached
+   * over HTTP.
+   */
+  async testInvoke({ headers = {}, retry404 = 0 }) {
+    const { functionName, log, lambda } = this;
+    const qualifier = this.cfg.version.replace(/\./g, '_');
+    const testPath = this.cfg.testPath || '/';
+    const requestId = crypto.randomUUID();
+
+    if (this.cfg.testHeaders) {
+      // eslint-disable-next-line no-param-reassign
+      headers = Object.assign(headers, this.cfg.testHeaders);
+    }
+
+    while (retry404 >= 0) {
+      log.info(chalk`--: invoking: {blueBright ${functionName}:${qualifier}:${testPath}} ...`);
+      const event = {
+        rawPath: testPath,
+        rawQueryString: '',
+        headers,
+        pathParameters: {
+          path: testPath.substring(1),
+        },
+        requestContext: {
+          http: {
+            method: 'GET',
+            path: testPath,
+          },
+          domainName: functionName,
+          requestId,
+        },
+        isBase64Encoded: false,
+      };
+
+      // eslint-disable-next-line no-await-in-loop
+      const { Payload, FunctionError } = await lambda.send(new InvokeCommand({
+        FunctionName: functionName,
+        Qualifier: qualifier,
+        Payload: Buffer.from(JSON.stringify(event)),
+      }));
+      const result = JSON.parse(Buffer.from(Payload).toString('utf-8'));
+
+      if (FunctionError) {
+        throw new Error(`test failed: ${FunctionError}: ${result.errorMessage || JSON.stringify(result)}`);
+      }
+
+      const { statusCode, body } = result;
+      if ((statusCode >= 200 && statusCode < 300) || statusCode === 301 || statusCode === 302) {
+        log.info(chalk`{green ok:} ${statusCode}`);
+        log.debug(chalk`{grey ${JSON.stringify(result.headers, 0, 2)}}`);
+        log.debug(chalk`{grey ${body}}`);
+        return;
+      }
+      if ((statusCode === 404 || statusCode === 500) && retry404) {
+        log.info(chalk`{yellow warn:} ${statusCode} (retry)`);
+        // eslint-disable-next-line no-param-reassign
+        retry404 -= 1;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => {
+          setTimeout(resolve, 1500);
+        });
+      } else {
+        throw new Error(`test failed: ${statusCode} ${JSON.stringify(result.headers, 0, 2)} ${body}`);
+      }
+    }
   }
 
   get fullFunctionName() {

--- a/test/aws.deployer.test.js
+++ b/test/aws.deployer.test.js
@@ -472,7 +472,11 @@ describe('AWS Deployer Test', () => {
   });
 
   it('test() invokes the lambda directly via InvokeCommand when apiId is none', async () => {
+    const testUrl = '/_status_check/healthcheck.json';
+
     const cfg = await createBaseConfig();
+    cfg.withTestUrl(testUrl);
+
     const awsCfg = new AWSConfig()
       .withAWSRegion('us-east-1')
       .withAWSApi('none');
@@ -482,7 +486,7 @@ describe('AWS Deployer Test', () => {
     // no API Gateway request is registered, so nock (with net connect disabled)
     // would fail the test if test() tried to reach one.
     const invokeScope = nock('https://lambda.us-east-1.amazonaws.com')
-      .post('/2015-03-31/functions/helix-services--static/invocations', (event) => event.rawPath === aws.functionPath
+      .post('/2015-03-31/functions/helix-services--static/invocations', (event) => event.rawPath === testUrl
         && event.requestContext.http.method === 'GET')
       .query({ Qualifier: '1_18_2' })
       .reply(200, {

--- a/test/aws.deployer.test.js
+++ b/test/aws.deployer.test.js
@@ -471,6 +471,32 @@ describe('AWS Deployer Test', () => {
     assert.strictEqual(aws.fullFunctionName, `https://example.execute-api.us-east-1.amazonaws.com${aws.functionPath}`);
   });
 
+  it('test() invokes the lambda directly via InvokeCommand when apiId is none', async () => {
+    const cfg = await createBaseConfig();
+    const awsCfg = new AWSConfig()
+      .withAWSRegion('us-east-1')
+      .withAWSApi('none');
+    const aws = new AWSDeployer(cfg, awsCfg);
+    await aws.init();
+
+    // no API Gateway request is registered, so nock (with net connect disabled)
+    // would fail the test if test() tried to reach one.
+    const invokeScope = nock('https://lambda.us-east-1.amazonaws.com')
+      .post('/2015-03-31/functions/helix-services--static/invocations', (event) => event.rawPath === aws.functionPath
+        && event.requestContext.http.method === 'GET')
+      .query({ Qualifier: '1_18_2' })
+      .reply(200, {
+        statusCode: 200,
+        headers: { 'content-type': 'text/plain' },
+        body: 'ok',
+        isBase64Encoded: false,
+      });
+
+    await aws.test();
+
+    assert.ok(invokeScope.isDone());
+  });
+
   it('creates stage when apiId equals create', async () => {
     const cfg = await createBaseConfig();
     const awsCfg = new AWSConfig()


### PR DESCRIPTION
## Summary
- `test()` now invokes the Lambda function directly via the `Invoke` API (with 404/500 retry) when `--aws-api=none`, instead of throwing an error
- Guards `BaseConfig#testPath` against `this.test` being unset (optional chaining)
- Adds a test covering the new `InvokeCommand` code path

## Test plan
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)